### PR TITLE
bug 609 osmc tracks support

### DIFF
--- a/OsmAndMapCreator/src/net/osmand/data/preparation/IndexVectorMapCreator.java
+++ b/OsmAndMapCreator/src/net/osmand/data/preparation/IndexVectorMapCreator.java
@@ -100,6 +100,13 @@ public class IndexVectorMapCreator extends AbstractIndexPartCreator {
 						propogated = new LinkedHashMap<String, String>();
 					}
 					propogated.put(ev.getKey(), ev.getValue());
+					MapRulType ruleType = renderingTypes.getEncodingRuleTypes().get(MapRenderingTypes.constructRuleKey(ev.getKey(), ev.getValue()));
+					if (ruleType != null) {
+						if (ruleType.getTargetTagValue() != null) {
+							MapRulType target = ruleType.getTargetTagValue();
+							propogated.put(target.getTag(), target.getValue()==null?"":target.getValue());
+						}
+					}
 				}
 			}
 			if(propogated != null) {


### PR DESCRIPTION
This pull requests add support for hiking tracks. Tracks are displayed as wide dashed lines with osmc symbols along the track.
Data are taken relations with osmc symbols. As renederer I used Touring-view_(more-contrast-and-details).

It is need to merge also mhamrle / Osmand,  mhamrle / OsmAnd-tools, mhamrle / OsmAnd-core
