### PR TITLE
Remove unnecessary returns

### DIFF
--- a/OsmAndMapCreator/src/net/osmand/data/index/ExtractGooglecodeAuthorization.java
+++ b/OsmAndMapCreator/src/net/osmand/data/index/ExtractGooglecodeAuthorization.java
@@ -216,8 +216,7 @@ public class ExtractGooglecodeAuthorization {
 	{
 		if (args.length < 2) {
 			System.out.println("Use: ExtractGooglecodeAuthorization gmailname gmailpassword");
-			return;
-		} else {
+        } else {
 			System.out.println(new ExtractGooglecodeAuthorization(true).getGooglecodeTokensForUpload(args[0], args[1]).toString());
 		}
 	}

--- a/OsmAndMapCreator/src/rtree/Node.java
+++ b/OsmAndMapCreator/src/rtree/Node.java
@@ -173,9 +173,8 @@ public class Node implements Cloneable //can be made abstract if leaf and non le
         //write the node
         writeNodeHeader(nodeIndex,0,prnt,size,elmtType);
       }
-            
-      return;
-    } 
+
+    }
     catch(IOException e){
       throw new IOException("Node.Node(new) : " + e.getMessage());
     }

--- a/OsmAndMapCreator/src/rtree/RTree.java
+++ b/OsmAndMapCreator/src/rtree/RTree.java
@@ -931,7 +931,6 @@ public class RTree //the tree that would be made
         trvsRPrePrint(chdNodes.getReadNode(fileHdr.getFile(),fileName,elmts[i].getPtr(),fileHdr));
       }
     }
-    return;
   }
   //-----------------------------------------------------------------------
   /**


### PR DESCRIPTION
Remove unnecessary return statements at the end of constructors and
methods returning void
