### PR TITLE
Replace StringBuffer by StringBuilder

### DIFF
--- a/OsmAndMapCreator/src/net/osmand/data/index/FTPFileUpload.java
+++ b/OsmAndMapCreator/src/net/osmand/data/index/FTPFileUpload.java
@@ -37,7 +37,7 @@ public class FTPFileUpload
    {
       if (ftpServer != null && fileName != null && source != null)
       {
-         StringBuffer sb = new StringBuffer( "ftp://" );
+         StringBuilder sb = new StringBuilder( "ftp://" );
          // check for authentication else assume its anonymous access.
          if (user != null && password != null)
          {
@@ -119,7 +119,7 @@ public class FTPFileUpload
    {
       if (ftpServer != null && fileName != null && destination != null)
       {
-         StringBuffer sb = new StringBuffer( "ftp://" );
+         StringBuilder sb = new StringBuilder( "ftp://" );
          // check for authentication else assume its anonymous access.
          if (user != null && password != null)
          {

--- a/OsmAndMapCreator/src/net/osmand/data/index/IndexUploader.java
+++ b/OsmAndMapCreator/src/net/osmand/data/index/IndexUploader.java
@@ -880,7 +880,7 @@ public class IndexUploader {
 			return b;
 
 		if (b == 1 || b == 2) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			int c;
 			do {
 				c = in.read();


### PR DESCRIPTION
java.lang.StringBuffer may be more efficiently declared as
java.lang.StringBuilder. java.lang.StringBuilder is a non-thread-safe
replacement for java.lang.StringBuffer, available in Java 5 and newer
