### PR TITLE
Fix .equals() comparison with empty string

### DIFF
--- a/OsmAndMapCreator/src/net/osmand/data/index/IndexBatchCreator.java
+++ b/OsmAndMapCreator/src/net/osmand/data/index/IndexBatchCreator.java
@@ -238,7 +238,7 @@ public class IndexBatchCreator {
 		}
 		
 		String szoomWaySmoothness = process.getAttribute("zoomWaySmoothness");
-		if(szoomWaySmoothness != null && !szoomWaySmoothness.equals("")){
+		if(szoomWaySmoothness != null && !szoomWaySmoothness.isEmpty()){
 			zoomWaySmoothness = Integer.parseInt(szoomWaySmoothness);
 		}
 		String f = process.getAttribute("renderingTypesFile");


### PR DESCRIPTION
It is normally more performant to test a String for emptiness by
comparing its .length() to zero instead.
Powered by InspectionGadgets
