### PR TITLE
Fix manual array to collection copy

### DIFF
--- a/OsmAndMapCreator/src/net/osmand/data/preparation/BasemapProcessor.java
+++ b/OsmAndMapCreator/src/net/osmand/data/preparation/BasemapProcessor.java
@@ -270,9 +270,7 @@ public class BasemapProcessor {
 				} else if(zoom < TILE_ZOOMLEVEL){
 					SimplisticQuadTree[] vis = rootTree.getOrCreateSubTree(x, y, zoom).getOrCreateSubTree(x, y, zoom)
 							.getAllChildren();
-					for (SimplisticQuadTree t : vis) {
-						newToVisit.add(t);
-					}
+                    Collections.addAll(newToVisit, vis);
 				}
 			}
 			toVisit = newToVisit;

--- a/OsmAndMapCreator/src/net/osmand/osm/MapRenderingTypesEncoder.java
+++ b/OsmAndMapCreator/src/net/osmand/osm/MapRenderingTypesEncoder.java
@@ -2,12 +2,7 @@ package net.osmand.osm;
 
 import gnu.trove.list.array.TIntArrayList;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import net.osmand.osm.edit.Entity;
@@ -256,9 +251,7 @@ public class MapRenderingTypesEncoder extends MapRenderingTypes {
 				}
 				rType.updateFreq();
 				if (rType.names != null) {
-					for (int i = 0; i < rType.names.length; i++) {
-						tempList.add(rType.names[i]);
-					}
+                    Collections.addAll(tempList, rType.names);
 				}
 
 				if (!rType.onlyNameRef) {


### PR DESCRIPTION
Such constructs may be replaced by a call to
Collection.addAll(Arrays.asList()) or Collections.addAll().
Powered by InspectionGadgets
