### PR TITLE
Fix concatenation with empty string

### DIFF
--- a/OsmAndMapCreator/src/net/osmand/data/index/DownloaderIndexFromGoogleCode.java
+++ b/OsmAndMapCreator/src/net/osmand/data/index/DownloaderIndexFromGoogleCode.java
@@ -136,7 +136,7 @@ public class DownloaderIndexFromGoogleCode {
 		connection.setConnectTimeout(15000);
 		connection.setRequestMethod("POST"); //$NON-NLS-1$
 		connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");  //$NON-NLS-1$//$NON-NLS-2$
-		connection.setRequestProperty("Content-Length", requestBody.length()+""); //$NON-NLS-1$ //$NON-NLS-2$
+		connection.setRequestProperty("Content-Length", String.valueOf(requestBody.length())); //$NON-NLS-1$ //$NON-NLS-2$
 		
 		connection.setDoInput(true);
 		connection.setDoOutput(true);

--- a/OsmAndMapCreator/src/net/osmand/data/index/ExtractGooglecodeAuthorization.java
+++ b/OsmAndMapCreator/src/net/osmand/data/index/ExtractGooglecodeAuthorization.java
@@ -101,7 +101,7 @@ public class ExtractGooglecodeAuthorization {
 				"https://www.google.com/accounts/ServiceLogin?service=code&ltmpl=phosting&continue=http%3A%2F%2Fcode.google.com%2Fp%2Fosmand%2Fdownloads%2Fdelete%3Fname%3Den-tts_0.voice.zip");
 		conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:5.0) Gecko/20100101 Firefox/5.0");
 		conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded"); //$NON-NLS-1$ //$NON-NLS-
-		conn.setRequestProperty("Content-Length", data.length() + "");
+		conn.setRequestProperty("Content-Length", String.valueOf(data.length()));
 		OutputStreamWriter writer = new OutputStreamWriter(conn.getOutputStream());
 
 		// write parameters

--- a/OsmAndMapCreator/src/net/osmand/data/index/IndexUploader.java
+++ b/OsmAndMapCreator/src/net/osmand/data/index/IndexUploader.java
@@ -772,7 +772,7 @@ public class IndexUploader {
 		if(serverName.startsWith("ftp://")){
 			serverName = serverName.substring("ftp://".length());
 		}
-		upload.upload(serverName, credentials.password, credentials.password, credentials.path + "" + f.getName(), f, 1 << 15);
+		upload.upload(serverName, credentials.password, credentials.password, credentials.path + f.getName(), f, 1 << 15);
 		log.info("Finish uploading file index");
 	}
 	

--- a/OsmAndMapCreator/src/net/osmand/data/index/WikiIndexer.java
+++ b/OsmAndMapCreator/src/net/osmand/data/index/WikiIndexer.java
@@ -654,8 +654,8 @@ public class WikiIndexer {
 			streamWriter.writeStartElement("node");
 			id++;
 			streamWriter.writeAttribute("id", "-" + cid);
-			streamWriter.writeAttribute("lat", lat + "");
-			streamWriter.writeAttribute("lon", lon + "");
+			streamWriter.writeAttribute("lat", String.valueOf(lat));
+			streamWriter.writeAttribute("lon", String.valueOf(lon));
 
 			streamWriter.writeCharacters("\n  ");
 			streamWriter.writeStartElement("tag");

--- a/OsmAndMapCreator/src/net/osmand/data/preparation/OsmDbCreator.java
+++ b/OsmAndMapCreator/src/net/osmand/data/preparation/OsmDbCreator.java
@@ -128,14 +128,14 @@ public class OsmDbCreator implements IOsmStorageFilter {
 			ArraySerializer.endArray(builder);
 		}
 		if (e instanceof Node) {
-			ArraySerializer.value(builder, ((float) ((Node) e).getLatitude()) + "", false);
-			ArraySerializer.value(builder, ((float) ((Node) e).getLongitude()) + "", false);
+			ArraySerializer.value(builder, String.valueOf((float) ((Node) e).getLatitude()), false);
+			ArraySerializer.value(builder, String.valueOf((float) ((Node) e).getLongitude()), false);
 		} else if (e instanceof Way) {
 			ArraySerializer.startArray(builder, false);
 			boolean f = true;
 			TLongArrayList nodeIds = ((Way) e).getNodeIds();
 			for (int j = 0; j < nodeIds.size(); j++) {
-				ArraySerializer.value(builder, nodeIds.get(j) + "", f);
+				ArraySerializer.value(builder, String.valueOf(nodeIds.get(j)), f);
 				f = false;
 			}
 			ArraySerializer.endArray(builder);
@@ -145,7 +145,7 @@ public class OsmDbCreator implements IOsmStorageFilter {
 			boolean f = true;
 			for(Entry<EntityId, String> l : ((Relation) e).getMembersMap().entrySet()) {
 				String k = l.getKey().getType() == EntityType.NODE ? "0" : (l.getKey().getType() == EntityType.WAY ? "1" : "2");
-				ArraySerializer.value(builder, k +""+l.getKey().getId(), f);
+				ArraySerializer.value(builder, k + l.getKey().getId(), f);
 				f = false;
 				ArraySerializer.value(builder, l.getValue(), f);
 			}
@@ -181,8 +181,7 @@ public class OsmDbCreator implements IOsmStorageFilter {
 				database.write(options, batch);
 				batch = new DBWriteBatch();
 				long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-				log.info("" + Runtime.getRuntime().totalMemory() / (1024 * 1024) + " MB Total " + (usedMemory / (1024 * 1024))
-						+ " MB used memory");
+				log.info(Runtime.getRuntime().totalMemory() / (1024 * 1024) + " MB Total " + (usedMemory / (1024 * 1024)) + " MB used memory");
 				currentCountNode = 0;
 			}
 		} else {

--- a/OsmAndMapCreator/src/net/osmand/map/RegionsRegistryConverter.java
+++ b/OsmAndMapCreator/src/net/osmand/map/RegionsRegistryConverter.java
@@ -119,7 +119,7 @@ public class RegionsRegistryConverter {
 		}
 		
 		String size = reg.getAttribute("size");
-		String sz = r.getTileSize()+"";
+		String sz = String.valueOf(r.getTileSize());
 		if(!size.equals(sz)) {
 			System.out.println("Region " + rgName);
 			System.out.println("Validate size '" + size + "' != '" +sz +"'");

--- a/OsmAndMapCreator/src/net/osmand/osm/io/OsmBaseStoragePbf.java
+++ b/OsmAndMapCreator/src/net/osmand/osm/io/OsmBaseStoragePbf.java
@@ -81,11 +81,11 @@ public class OsmBaseStoragePbf extends OsmBaseStorage {
 						timestamp += n.getDenseinfo().getTimestamp(i);
 						uid += n.getDenseinfo().getUid(i);
 						user += n.getDenseinfo().getUserSid(i);
-						info.setChangeset((changeset) + ""); //$NON-NLS-1$
+						info.setChangeset(String.valueOf(changeset)); //$NON-NLS-1$
 						info.setTimestamp(format.format(new Date(date_granularity * (timestamp))));
 						info.setUser(getStringById(user));
-						info.setUid(uid + ""); //$NON-NLS-1$
-						info.setVersion(n.getDenseinfo().getVersion(i) + ""); //$NON-NLS-1$
+						info.setUid(String.valueOf(uid)); //$NON-NLS-1$
+						info.setVersion(String.valueOf(n.getDenseinfo().getVersion(i))); //$NON-NLS-1$
 						info.setVisible("true"); //$NON-NLS-1$
 					}
 					if (!tagsEmpty) {
@@ -104,11 +104,11 @@ public class OsmBaseStoragePbf extends OsmBaseStorage {
 
 			protected EntityInfo parseEntityInfo(Info i) {
 				EntityInfo info = new EntityInfo();
-				info.setChangeset(i.getChangeset() + ""); //$NON-NLS-1$
+				info.setChangeset(String.valueOf(i.getChangeset())); //$NON-NLS-1$
 				info.setTimestamp(format.format(getDate(i)));
 				info.setUser(getStringById(i.getUserSid()));
-				info.setUid(i.getUid() + ""); //$NON-NLS-1$
-				info.setVersion(i.getVersion() + ""); //$NON-NLS-1$
+				info.setUid(String.valueOf(i.getUid())); //$NON-NLS-1$
+				info.setVersion(String.valueOf(i.getVersion())); //$NON-NLS-1$
 				info.setVisible("true"); //$NON-NLS-1$
 				return info;
 			}

--- a/OsmAndMapCreator/src/net/osmand/osm/io/OsmStorageWriter.java
+++ b/OsmAndMapCreator/src/net/osmand/osm/io/OsmStorageWriter.java
@@ -97,9 +97,9 @@ public class OsmStorageWriter {
 		streamWriter.writeAttribute(ATTR_VERSION, "0.6");
 		for(Node n : nodes){
 			writeStartElement(streamWriter, ELEM_NODE, INDENT);
-			streamWriter.writeAttribute(ATTR_LAT, n.getLatitude()+"");
-			streamWriter.writeAttribute(ATTR_LON, n.getLongitude()+"");
-			streamWriter.writeAttribute(ATTR_ID, n.getId()+"");
+			streamWriter.writeAttribute(ATTR_LAT, String.valueOf(n.getLatitude()));
+			streamWriter.writeAttribute(ATTR_LON, String.valueOf(n.getLongitude()));
+			streamWriter.writeAttribute(ATTR_ID, String.valueOf(n.getId()));
 			writeEntityAttributes(streamWriter, n, entityInfo.get(EntityId.valueOf(n)));
 			writeTags(streamWriter, n);
 			writeEndElement(streamWriter, INDENT);
@@ -107,12 +107,12 @@ public class OsmStorageWriter {
 		
 		for(Way w : ways){
 			writeStartElement(streamWriter, ELEM_WAY, INDENT);
-			streamWriter.writeAttribute(ATTR_ID, w.getId()+"");
+			streamWriter.writeAttribute(ATTR_ID, String.valueOf(w.getId()));
 			writeEntityAttributes(streamWriter, w, entityInfo.get(EntityId.valueOf(w)));
 			TLongArrayList ids = w.getNodeIds();
 			for(int i=0; i< ids.size(); i++){
 				writeStartElement(streamWriter, ELEM_ND, INDENT2);
-				streamWriter.writeAttribute(ATTR_REF, ids.get(i)+"");
+				streamWriter.writeAttribute(ATTR_REF, String.valueOf(ids.get(i)));
 				writeEndElement(streamWriter, INDENT2);
 			}
 			writeTags(streamWriter, w);
@@ -121,11 +121,11 @@ public class OsmStorageWriter {
 		
 		for(Relation r : relations){
 			writeStartElement(streamWriter, ELEM_RELATION, INDENT);
-			streamWriter.writeAttribute(ATTR_ID, r.getId()+"");
+			streamWriter.writeAttribute(ATTR_ID, String.valueOf(r.getId()));
 			writeEntityAttributes(streamWriter, r, entityInfo.get(EntityId.valueOf(r)));
 			for(Entry<EntityId, String> e : r.getMembersMap().entrySet()){
 				writeStartElement(streamWriter, ELEM_MEMBER, INDENT2);
-				streamWriter.writeAttribute(ATTR_REF, e.getKey().getId()+"");
+				streamWriter.writeAttribute(ATTR_REF, String.valueOf(e.getKey().getId()));
 				String s = e.getValue();
 				if(s == null){
 					s = ""; 

--- a/OsmAndMapCreator/src/net/osmand/osm/util/AHSupermarketResolver.java
+++ b/OsmAndMapCreator/src/net/osmand/osm/util/AHSupermarketResolver.java
@@ -175,18 +175,18 @@ public class AHSupermarketResolver {
 				Entity e = storage.getRegisteredEntities().get(id);
 				EntityInfo info = storage.getRegisteredEntityInfo().get(id);
 				Map<String, String> newTags = new LinkedHashMap<String, String>();
-				String p = props.get("format")+"";
+				String p = String.valueOf(props.get("format"));
 				//IMPORTANT : comment what information should be updated or check
 				String name = "Albert Heijn";
 				if(!p.equals("AH")){
 					name += " " + p;
 				}
 				newTags.put("name", name);
-				newTags.put("phone", props.get("phone")+"");
-				newTags.put("addr:city", props.get("city")+"");
-				newTags.put("addr:street", props.get("street")+"");
-				newTags.put("addr:housenumber", props.get("housenr")+"");
-				newTags.put("addr:postcode", props.get("zip")+"");
+				newTags.put("phone", String.valueOf(props.get("phone")));
+				newTags.put("addr:city", String.valueOf(props.get("city")));
+				newTags.put("addr:street", String.valueOf(props.get("street")));
+				newTags.put("addr:housenumber", String.valueOf(props.get("housenr")));
+				newTags.put("addr:postcode", String.valueOf(props.get("zip")));
 				
 				JSONArray o = (JSONArray) props.get("hours");
 				OpeningHoursParser.OpeningHours rules = new OpeningHoursParser.OpeningHours();
@@ -196,8 +196,8 @@ public class AHSupermarketResolver {
 					
 					if(!obj.isNull("C") && obj.getBoolean("C")){
 					} else {
-						String opened  = obj.get("F")+"";
-						String closed = obj.get("U")+"";
+						String opened  = String.valueOf(obj.get("F"));
+						String closed = String.valueOf(obj.get("U"));
 						int start = Integer.parseInt(opened.substring(0, 2)) * 60 + Integer.parseInt(opened.substring(2));
 						int end = Integer.parseInt(closed.substring(0, 2)) * 60 + Integer.parseInt(closed.substring(2));
 						if(prev != null && prev.getStartTime() == start && prev.getEndTime() == end){

--- a/OsmAndMapCreator/src/net/osmand/swing/MapRouterLayer.java
+++ b/OsmAndMapCreator/src/net/osmand/swing/MapRouterLayer.java
@@ -457,10 +457,10 @@ public class MapRouterLayer implements MapPanelLayer {
 				// possibly hide that API key because it is privacy of osmand
 				uri.append("http://routes.cloudmade.com/A6421860EBB04234AB5EF2D049F2CD8F/api/0.3/");
 				 
-				uri.append(start.getLatitude()+"").append(",");
-				uri.append(start.getLongitude()+"").append(",");
-				uri.append(end.getLatitude()+"").append(",");
-				uri.append(end.getLongitude()+"").append("/");
+				uri.append(String.valueOf(start.getLatitude())).append(",");
+				uri.append(String.valueOf(start.getLongitude())).append(",");
+				uri.append(String.valueOf(end.getLatitude())).append(",");
+				uri.append(String.valueOf(end.getLongitude())).append("/");
 				uri.append("car.gpx").append("?lang=ru");
 
 				URL url = new URL(uri.toString());

--- a/OsmAndMapCreator/src/net/osmand/swing/OsmExtractionPreferencesDialog.java
+++ b/OsmAndMapCreator/src/net/osmand/swing/OsmExtractionPreferencesDialog.java
@@ -151,7 +151,7 @@ public class OsmExtractionPreferencesDialog extends JDialog {
         
         routingMode = new JTextField();
         
-        routingMode.setText(DataExtractionSettings.getSettings().getRouteMode() +"");
+        routingMode.setText(DataExtractionSettings.getSettings().getRouteMode());
         panel.add(routingMode);
         constr = new GridBagConstraints();
         constr.weightx = 1;

--- a/OsmAndMapCreator/src/net/osmand/swing/SelectPointDialog.java
+++ b/OsmAndMapCreator/src/net/osmand/swing/SelectPointDialog.java
@@ -100,7 +100,7 @@ public class SelectPointDialog extends JDialog {
 		l.setConstraints(label, constr);
 
 		latPosition = new JTextField();
-		latPosition.setText(((float)position.getLatitude())+""); //$NON-NLS-1$
+		latPosition.setText(String.valueOf((float) position.getLatitude())); //$NON-NLS-1$
 		panel.add(latPosition);
 		constr = new GridBagConstraints();
 		constr.fill = GridBagConstraints.HORIZONTAL;
@@ -121,7 +121,7 @@ public class SelectPointDialog extends JDialog {
 
 		lonPosition = new JTextField();
 		// Give hint about wms 
-		lonPosition.setText(((float)position.getLongitude())+""); //$NON-NLS-1$
+		lonPosition.setText(String.valueOf((float) position.getLongitude())); //$NON-NLS-1$
 		panel.add(lonPosition);
 		constr = new GridBagConstraints();
 		constr.weightx = 1;


### PR DESCRIPTION
Reports string concatenations where one of the arguments is the empty
string. Such a concatenation is unnecessary and inefficient,
particularly when used as an idiom for formatting non-String objects or
primitives into Strings.
Powered by InspectionGadgets
