### PR TITLE
Fix zero-length array argument

### DIFF
--- a/OsmAndMapCreator/src/crosby/binary/StringTable.java
+++ b/OsmAndMapCreator/src/crosby/binary/StringTable.java
@@ -3,6 +3,7 @@ package crosby.binary;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Set;
 
 import com.google.protobuf.ByteString;
 
@@ -46,7 +47,8 @@ public class StringTable {
             }
         };
 
-        set = counts.keySet().toArray(new String[0]);
+        Set<String> var = counts.keySet();
+        set = var.toArray(new String[var.size()]);
         if (set.length > 0) {
           // Sort based on the frequency.
           Arrays.sort(set, comparator);


### PR DESCRIPTION
Reports any call to toArray() on an object of type or subtype
java.util.Collection with a zero-length array argument. When passing in
an array of too small size, the toArray() method has to construct a new
array of the right size using reflection. This has significantly worse
performance than passing in an array of at least the size of the
collection itself.
Powered by InspectionGadgets
