### PR TITLE
Use more stable URL for zlib download (sf.net).

### DIFF
--- a/mirror_externals.sh
+++ b/mirror_externals.sh
@@ -3,4 +3,4 @@ curl -L http://sourceforge.net/projects/freetype/files/freetype2/2.4.10/freetype
 curl -L http://sourceforge.net/projects/giflib/files/giflib-4.x/giflib-4.2.1.tar.bz2/download > giflib-4.2.1.tar.bz2
 curl -L http://www.ijg.org/files/jpegsrc.v8d.tar.gz > jpegsrc.v8d.tar.gz
 curl -L http://sourceforge.net/projects/libpng/files/libpng15/older-releases/1.5.13/libpng-1.5.13.tar.bz2/download > libpng-1.5.13.tar.bz2
-curl -L http://zlib.net/zlib-1.2.7.tar.bz2 > zlib-1.2.7.tar.bz2
+curl -L http://sourceforge.net/projects/libpng/files/zlib/1.2.7/zlib-1.2.7.tar.gz/download > zlib-1.2.7.tar.bz2


### PR DESCRIPTION
Apparently, zlib.net hosts only the latest version. New URL comes from link
published on zlib.net page.
