### PR TITLE
Missing motorway_links breaks routing badly

### DIFF
--- a/obf-generation/basemap/query_roads_osm.py
+++ b/obf-generation/basemap/query_roads_osm.py
@@ -76,6 +76,7 @@ def process_roads(cond, filename, fields):
 
 if __name__ == "__main__":
 	process_roads("highway='motorway'", "line_motorway.osm", ['highway', 'junction', 'route'])
+        process_roads("highway='motorway_link'", "line_motorway.osm", ['highway', 'junction', 'route'])
 	process_roads("highway='trunk'", "line_trunk.osm", ['highway', 'junction', 'route'])
 	process_roads("highway='primary'", "line_primary.osm", ['highway', 'junction', 'route'])
 	process_roads("highway='secondary'", "line_secondary.osm", ['highway', 'junction', 'route'])


### PR DESCRIPTION
Osmand routing fails with missing mororway_link's. Or even produces very bad routes.