### PR TITLE
updated windows batch file to inlcude option with increased heap memory

### DIFF
--- a/java-tools/OsmAndMapCreator/src/main/resources/OsmAndMapCreator.bat
+++ b/java-tools/OsmAndMapCreator/src/main/resources/OsmAndMapCreator.bat
@@ -1,2 +1,5 @@
-REM the JVM. With the below settings the heap size (Available memory for the application)
+REM Use the JVM with standard settings.
 start javaw.exe -Djava.util.logging.config.file=logging.properties -jar OsmAndMapCreator.jar
+
+REM Use the JVM with the below settings to increase the heap size (Available memory for the application)
+REM start javaw.exe -Xmx4096m -Djava.util.logging.config.file=logging.properties -jar OsmAndMapCreator.jar


### PR DESCRIPTION
Converting very large pbf files (tested with Thailand) leads to an "out of java heap memory error" on windows when running with the default parameters.

To have an alternative command line option embedded in the batch file helps a lot and avoids unnecessary look-ups to find the right parameters.
