### PR TITLE
#9693 (lcn=yes) fix

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexVectorMapCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexVectorMapCreator.java
@@ -731,23 +731,6 @@ public class IndexVectorMapCreator extends AbstractIndexPartCreator {
 			}
 			tagsTransformer.addPropogatedTags(renderingTypes, EntityConvertApplyType.MAP, e);
 			
-			//out-of-necessity solution. There shouldn't be a network tags on segments outside relations, but there are still many such cases on OSM
-			if (e.getTag("network") == null) {				
-				if (e.getTag("lcn") != null) {
-					e.putTag("network", "lcn");
-					e.putTag("route_bicycle", "");
-				} else if (e.getTag("rcn") != null) {
-					e.putTag("network", "rcn");
-					e.putTag("route_bicycle", "");
-				} else if (e.getTag("ncn") != null) {
-					e.putTag("network", "ncn");
-					e.putTag("route_bicycle", "");
-				} else if (e.getTag("icn") != null) {
-					e.putTag("network", "icn");
-					e.putTag("route_bicycle", "");
-				}
-			}
-			
 			// manipulate what kind of way to load
 			long originalId = e.getId();
 			long assignedId = e.getId();

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexVectorMapCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexVectorMapCreator.java
@@ -730,6 +730,24 @@ public class IndexVectorMapCreator extends AbstractIndexPartCreator {
 						JapaneseTranslitHelper.getEnglishTransliteration(e.getTag(OSMTagKey.NAME.getValue())));
 			}
 			tagsTransformer.addPropogatedTags(renderingTypes, EntityConvertApplyType.MAP, e);
+			
+			//out-of-necessity solution. There shouldn't be a network tags on segments outside relations, but there are still many such cases on OSM
+			if (e.getTag("network") == null) {				
+				if (e.getTag("lcn") != null) {
+					e.putTag("network", "lcn");
+					e.putTag("route_bicycle", "");
+				} else if (e.getTag("rcn") != null) {
+					e.putTag("network", "rcn");
+					e.putTag("route_bicycle", "");
+				} else if (e.getTag("ncn") != null) {
+					e.putTag("network", "ncn");
+					e.putTag("route_bicycle", "");
+				} else if (e.getTag("icn") != null) {
+					e.putTag("network", "icn");
+					e.putTag("route_bicycle", "");
+				}
+			}
+			
 			// manipulate what kind of way to load
 			long originalId = e.getId();
 			long assignedId = e.getId();

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/osm/RelationTagsPropagation.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/osm/RelationTagsPropagation.java
@@ -204,6 +204,7 @@ public class RelationTagsPropagation {
 	
 	public void addPropogatedTags(MapRenderingTypesEncoder renderingTypes, EntityConvertApplyType tp, Entity e) {
 		EntityId eid = EntityId.valueOf(e);
+		String looseNetworkTag = getNetworkTagIfPresent(e);
 		PropagateEntityTags proptags = propogatedTags.get(eid);
 		if (proptags != null) {
 			Iterator<Entry<String, String>> iterator = proptags.putThroughTags.entrySet().iterator();
@@ -246,10 +247,25 @@ public class RelationTagsPropagation {
 					mod++;
 				}
 			}
-		}		
+		}
+		if (looseNetworkTag != null && e.getTag("network") == null) {
+			e.putTag("network", looseNetworkTag);
+			e.putTag("route_bicycle", "");
+		}
 	}
 	
-	
+	private String getNetworkTagIfPresent(Entity e) {
+			if (e.getTag("icn") != null) {
+				return "icn";
+			} else if (e.getTag("ncn") != null) {
+				return "ncn";
+			} else if (e.getTag("rcn") != null) {
+				return "rcn";
+			} else if (e.getTag("lcn") != null) {
+				return "lcn";
+			}
+			return null;
+	}
 	
 	private static String sortAndAttachUniqueValue(String list, String value) {
 		if(list == null) {


### PR DESCRIPTION
In case there is no relation, but are still network tags on segment - we add tags to correctly mark segments with bicycle routes 'on'.