### PR TITLE
giving a chance to source=* to be used in obf creation process

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/OsmDbCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/OsmDbCreator.java
@@ -39,7 +39,7 @@ public class OsmDbCreator implements IOsmStorageFilter {
 	public static final int BATCH_SIZE_OSM = 100000;
 
 	// do not store these tags in the database, just ignore them
-	final String[] tagsToIgnore= {"created_by","source","converted_by"};
+	final String[] tagsToIgnore= {"created_by","converted_by"};
 	
 	DBDialect dialect;
 	int currentCountNode = 0;


### PR DESCRIPTION
Currently, the source tag is being ignored in the OBF creation process and not given a chance to be used in the tags conversion process (rendering_types.xml)

For this reason, I have used so far `source:geometry` to detect a ground survey (`survey=ground`) however members of my local OSM community do not want to migrate existing e.g source=GPS tagging because it is commonly used in Garmin implementations.

Once this PR is merged, I will be able to use the source rules in this other PR:
https://github.com/osmandapp/OsmAnd-resources/pull/714
