### PR TITLE
add transliteration for chinese lang

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/build.gradle
+++ b/java-tools/OsmAndMapCreatorUtilities/build.gradle
@@ -74,8 +74,10 @@ dependencies {
 	//override 1.0 version
 	implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
 	
-	//japaneese transliteration
+	//japanese transliteration
 	implementation 'com.atilika.kuromoji:kuromoji-ipadic:0.9.0'
+	//chinese transliteration
+	implementation 'com.belerweb:pinyin4j:2.5.0'
 
 	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
 

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
@@ -107,6 +107,7 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 		tempAmenityList.clear();
 		tagsTransform.addPropogatedTags(renderingTypes, EntityConvertApplyType.POI, e);
 		icc.translitJapaneseNames(e, settings.addRegionTag);
+		icc.translitChineseNames(e, settings.addRegionTag);
 		Map<String, String> tags = e.getTags();
 		Map<String, String> etags = renderingTypes.transformTags(tags, EntityType.valueOf(e), EntityConvertApplyType.POI);
 		boolean privateReg = "private".equals(e.getTag("access"));

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexRouteRelationCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexRouteRelationCreator.java
@@ -94,6 +94,7 @@ public class IndexRouteRelationCreator {
 				}
 				w.replaceTags(tags);
 				icc.translitJapaneseNames(e, settings.addRegionTag);
+				icc.translitChineseNames(e, settings.addRegionTag);
 				for (int level = 0; level < mapZooms.size(); level++) {
 					icc.getIndexMapCreator().processMainEntity(w, w.getId(), w.getId(), level, tags);
 				}

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexTransportCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexTransportCreator.java
@@ -714,6 +714,7 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 
 	private void indexTransportRoute(Relation rel, List<TransportRoute> troutes, IndexCreationContext icc) throws SQLException {
 		icc.translitJapaneseNames(rel, settings.addRegionTag);
+		icc.translitChineseNames(rel, settings.addRegionTag);
 		String ref = rel.getTag(OSMTagKey.REF);
 		String route = rel.getTag(OSMTagKey.ROUTE);
 		String operator = rel.getTag(OSMTagKey.OPERATOR);
@@ -1102,6 +1103,7 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 			}
 			Entity e = entry.getEntity();
 			icc.translitJapaneseNames(e, settings.addRegionTag);
+			icc.translitChineseNames(e, settings.addRegionTag);
 			if (role.startsWith("platform")) {
 				platformsAndStops.add(e);
 				platforms.add(e);

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexVectorMapCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexVectorMapCreator.java
@@ -715,6 +715,7 @@ public class IndexVectorMapCreator extends AbstractIndexPartCreator {
 				icc.calcRegionTag(e, true);
 			}
 			icc.translitJapaneseNames(e, settings.addRegionTag);
+			icc.translitChineseNames(e, settings.addRegionTag);
 			tagsTransformer.addPropogatedTags(renderingTypes, EntityConvertApplyType.MAP, e);
 			// manipulate what kind of way to load
 			long originalId = e.getId();

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/util/ChineseTranslitHelper.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/util/ChineseTranslitHelper.java
@@ -1,0 +1,57 @@
+package net.osmand.util;
+
+import net.sourceforge.pinyin4j.PinyinHelper;
+import net.sourceforge.pinyin4j.format.HanyuPinyinCaseType;
+import net.sourceforge.pinyin4j.format.HanyuPinyinOutputFormat;
+import net.sourceforge.pinyin4j.format.HanyuPinyinToneType;
+import net.sourceforge.pinyin4j.format.HanyuPinyinVCharType;
+import net.sourceforge.pinyin4j.format.exception.BadHanyuPinyinOutputFormatCombination;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.StringJoiner;
+
+import static net.sourceforge.pinyin4j.format.HanyuPinyinCaseType.LOWERCASE;
+import static net.sourceforge.pinyin4j.format.HanyuPinyinToneType.*;
+import static net.sourceforge.pinyin4j.format.HanyuPinyinVCharType.*;
+
+public class ChineseTranslitHelper {
+    
+    private ChineseTranslitHelper() {}
+    
+    private static final String CHINESE_LETTERS = "[\\u4E00-\\u9FA5]+";
+    private static final String DELIMITER = " ";
+    
+    public static String getPinyinTransliteration(String name) {
+        return nameToPinyin(name, getToneMarkPinyinFormat());
+    }
+    
+    public static String nameToPinyin(String name, HanyuPinyinOutputFormat pinyinFormat) {
+        StringJoiner pinyinWords = new StringJoiner(DELIMITER);
+        try {
+            for (char word : name.toCharArray()) {
+                String wordStr = Character.toString(word);
+                if (wordStr.matches(CHINESE_LETTERS)) {
+                    String[] py = PinyinHelper.toHanyuPinyinStringArray(word, pinyinFormat);
+                    pinyinWords.add(StringUtils.join(py));
+                } else {
+                    pinyinWords.add(wordStr);
+                }
+            }
+        } catch (BadHanyuPinyinOutputFormatCombination e) {
+            e.printStackTrace();
+        }
+        return pinyinWords.toString();
+    }
+    
+    private static HanyuPinyinOutputFormat getToneMarkPinyinFormat() {
+        return getPinyinFormat(LOWERCASE, WITH_TONE_MARK, WITH_U_UNICODE);
+    }
+    
+    public static HanyuPinyinOutputFormat getPinyinFormat(HanyuPinyinCaseType caseType, HanyuPinyinToneType toneType, HanyuPinyinVCharType charType) {
+        HanyuPinyinOutputFormat format = new HanyuPinyinOutputFormat();
+        format.setCaseType(caseType);
+        format.setToneType(toneType);
+        format.setVCharType(charType);
+        return format;
+    }
+}


### PR DESCRIPTION
PinyinFormat contains tone marks. It can be changed using library api.

Examples:
https://www.openstreetmap.org/node/445776541
after generate map:
transportation: toll_booth 新洲收费站 Lat 23.099812 Lon 113.346466 osmid=445776541  name:en='xīn zhōu shōu fèi zhàn' name:zh='新洲站'

https://www.openstreetmap.org/node/3141524576
after generate map:
transportation: bus_station 莲溪 Lat 22.379658 Lon 113.22862 osmid=3141524576  bus_yes='yes' operator='珠海公交' name:en='Lian Xi' name:zh_pinyin='Lian Xi'