### PR TITLE
MapRenderingTypesEncoder: call calculateIntegrity only once

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/osm/MapRenderingTypesEncoder.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/osm/MapRenderingTypesEncoder.java
@@ -467,8 +467,9 @@ public class MapRenderingTypesEncoder extends MapRenderingTypes {
 			EntityConvertApplyType appType) {
 		if(tags.containsKey("highway") && entity == EntityType.WAY) {
 			tags = new LinkedHashMap<>(tags);
-			int integrity = calculateIntegrity(tags)[0];
-			int integrity_bicycle_routing = calculateIntegrity(tags)[1];
+			int[] integrityResult = calculateIntegrity(tags);
+			int integrity = integrityResult[0];
+			int integrity_bicycle_routing = integrityResult[1];
 			int max_integrity = 30;
 			int normalised_integrity_brouting = 0;
 			if (integrity_bicycle_routing >= 0) {


### PR DESCRIPTION
To improve speed:

MapRenderingTypesEncoder.java: transformIntegrityTags: call "calculateIntegrity" only once.