### PR TITLE
Set ordering for poi

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
@@ -540,9 +540,9 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 			Tree<PoiTileBox> rootZoomsTree) throws SQLException {
 		ResultSet rs;
 		if (useInMemoryCreator) {
-			rs = poiConnection.createStatement().executeQuery("SELECT x,y,type,subtype,id,additionalTags from poi");
+			rs = poiConnection.createStatement().executeQuery("SELECT x,y,type,subtype,id,additionalTags from poi ORDER BY id");
 		} else {
-			rs = poiConnection.createStatement().executeQuery("SELECT x,y,type,subtype from poi");
+			rs = poiConnection.createStatement().executeQuery("SELECT x,y,type,subtype from poi ORDER BY id");
 		}
 		rootZoomsTree.setNode(new PoiTileBox());
 


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd/issues/13765
Old table
sport: table_tennis  Lat 51.20041 Lon 6.601088 osmid=768713167 
sport: pitch  Lat 51.20041 Lon 6.601088 osmid=768713167 

sport: pitch  Lat 51.20037 Lon 6.601705 osmid=787531807 
sport: table_tennis  Lat 51.20037 Lon 6.601705 osmid=787531807

Must be:
sport: pitch  Lat 51.20041 Lon 6.601088 osmid=768713167 
sport: table_tennis  Lat 51.20041 Lon 6.601088 osmid=768713167 

sport: pitch  Lat 51.20037 Lon 6.601705 osmid=787531807 
sport: table_tennis  Lat 51.20037 Lon 6.601705 osmid=787531807