### PR TITLE
Hotfix misplaced removal of anonymous iOS devices

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/UserdataService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/UserdataService.java
@@ -398,11 +398,15 @@ public class UserdataService {
         pu.tokenTime = null;
         PremiumUserDevicesRepository.PremiumUserDevice device = new PremiumUserDevicesRepository.PremiumUserDevice();
         PremiumUserDevicesRepository.PremiumUserDevice sameDevice;
-        while ((sameDevice = devicesRepository.findTopByUseridAndDeviceidOrderByUdpatetimeDesc(pu.id,
-                deviceId)) != null) {
-            LOG.error("device-register: call delete-same-device (" + email + ") old-token (" + sameDevice.accesstoken + ")");
-            devicesRepository.delete(sameDevice);
-        }
+	    if (Algorithms.isEmpty(deviceId)) {
+		    LOG.error("device-register: avoid delete-anonymous-same-device (" + email + ")");
+	    } else {
+		    while ((sameDevice = devicesRepository.findTopByUseridAndDeviceidOrderByUdpatetimeDesc(pu.id,
+				    deviceId)) != null) {
+			    LOG.error("device-register: call delete-same-device (" + email + ")");
+			    devicesRepository.delete(sameDevice);
+		    }
+	    }
         device.lang = lang;
         device.brand = brand;
         device.model = model;


### PR DESCRIPTION
~15% of OsmAnd iOS users send device-register API requests with empty deviceId (see the snippets below).

Current implementation of delete-same-device code **always removes ALL devices** from Cloud in case if user has more than one iOS Cloud device with disabled sendAnonymousAppUsageData option.

To reproduce the bug, we need 2 iOS devices with the same Cloud account, both should have anonymous option setup. Register new device on 2nd "anonymous" device will remove 1st one.

Hotfix is proposed. Logging included.

```
- (NSString *) getUserIosId {
...
    if (![settings.sendAnonymousAppUsageData get])
        return @""; // might be empty
...
```

```
@implementation OARegisterUserCommand
...
NSString *deviceId = OsmAndApp.instance.getUserIosId;
params[@"deviceid"] = deviceId; // might be empty
```