### PR TITLE
Hotfix aid as not required for submit_analytics

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/ApiController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/ApiController.java
@@ -543,7 +543,7 @@ public class ApiController {
 								  @RequestParam() Long finishDate,
 								  @RequestParam() Integer nd,
 								  @RequestParam() Integer ns,
-								  @RequestParam() String aid,
+								  @RequestParam(required = false) String aid,
 								  @RequestParam() String version,
 								  @RequestParam() String lang,
 								  @RequestParam() MultipartFile file) throws IOException, SQLException {


### PR DESCRIPTION
```
public class AnalyticsHelper extends SQLiteOpenHelper {
...
	private static final String PARAM_USER_ID = "aid";
...
					if (app.isUserAndroidIdAllowed()) {
						additionalData.put(PARAM_USER_ID, app.getUserAndroidId());
					}
```

=>

`2024-08-17 16:12:23.574 WARN  [http-nio-127.0.0.1-8090-exec-1]: Resolved [org.springframework.web.bind.MissingServletRequestParameterException: Required request parameter 'aid' for method parameter type String is not present]`