### PR TITLE
Use OsmAnd-shared in/around OsmGpxWriteContext

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/OsmGpxWriteContext.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/OsmGpxWriteContext.java
@@ -463,11 +463,11 @@ public class OsmGpxWriteContext {
 			KFile file = new KFile(subArgs.get(0));
 			if (file.isDirectory() || file.name().endsWith(GPX_FILE_EXT) || file.name().endsWith(".gpx.gz")) {
 				OsmGpxWriteContext.QueryParams qp = new OsmGpxWriteContext.QueryParams();
-				qp.osmFile = File.createTempFile(KAlgorithms.INSTANCE.getFileNameWithoutExtension(file), ".osm");
+				qp.osmFile = File.createTempFile(file.getFileNameWithoutExtension(), ".osm");
 				OsmGpxWriteContext ctx = new OsmGpxWriteContext(qp);
 				File dir = new File(file.isDirectory() ? file.name() : file.parent().name());
 				File tmpFolder = new File(dir, String.valueOf(System.currentTimeMillis()));
-				File targetObf = new File(dir, KAlgorithms.INSTANCE.getFileNameWithoutExtension(file) + BINARY_MAP_INDEX_EXT);
+				File targetObf = new File(dir, file.getFileNameWithoutExtension() + BINARY_MAP_INDEX_EXT);
 				List<KFile> files = new ArrayList<>();
 				if (file.isDirectory()) {
 					files = Arrays.asList(Objects.requireNonNull(file.listFiles()));
@@ -475,7 +475,7 @@ public class OsmGpxWriteContext {
 					files.add(file);
 				}
 				if (!files.isEmpty()) {
-					ctx.writeObf(null, files, tmpFolder, KAlgorithms.INSTANCE.getFileNameWithoutExtension(file), targetObf);
+					ctx.writeObf(null, files, tmpFolder, file.getFileNameWithoutExtension(), targetObf);
 				}
 				if (!qp.osmFile.delete()) {
 					qp.osmFile.deleteOnExit();

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/OsmGpxWriteContext.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/OsmGpxWriteContext.java
@@ -34,19 +34,22 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 
+import net.osmand.shared.io.KFile;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlSerializer;
 
 import net.osmand.IProgress;
 import net.osmand.PlatformUtil;
 import net.osmand.binary.MapZooms;
-import net.osmand.data.QuadRect;
-import net.osmand.gpx.GPXFile;
-import net.osmand.gpx.GPXTrackAnalysis;
-import net.osmand.gpx.GPXUtilities;
-import net.osmand.gpx.GPXUtilities.Track;
-import net.osmand.gpx.GPXUtilities.TrkSegment;
-import net.osmand.gpx.GPXUtilities.WptPt;
+import net.osmand.shared.util.KAlgorithms;
+import net.osmand.shared.data.KQuadRect;
+import net.osmand.shared.gpx.GpxFile;
+import net.osmand.shared.gpx.GpxTrackAnalysis;
+import net.osmand.shared.gpx.GpxUtilities;
+import net.osmand.shared.gpx.GpxUtilities.PointsGroup;
+import net.osmand.shared.gpx.primitives.Track;
+import net.osmand.shared.gpx.primitives.TrkSegment;
+import net.osmand.shared.gpx.primitives.WptPt;
 import net.osmand.obf.preparation.IndexCreator;
 import net.osmand.obf.preparation.IndexCreatorSettings;
 import net.osmand.obf.preparation.IndexHeightData;
@@ -75,12 +78,12 @@ public class OsmGpxWriteContext {
 		boolean isOnePointIn = false;
 		boolean testPoints = qp.minlat != OsmGpxFile.ERROR_NUMBER || qp.minlon != OsmGpxFile.ERROR_NUMBER
 				|| qp.maxlat != OsmGpxFile.ERROR_NUMBER || qp.maxlon != OsmGpxFile.ERROR_NUMBER;
-		for (WptPt p : t.points) {
-			if (p.lat >= 90 || p.lat <= -90 || p.lon >= 180 || p.lon <= -180) {
+		for (WptPt p : t.getPoints()) {
+			if (p.getLat() >= 90 || p.getLat() <= -90 || p.getLon() >= 180 || p.getLon() <= -180) {
 				return false;
 			}
 			if (testPoints) {
-				if (p.lat >= qp.minlat && p.lat <= qp.maxlat && p.lon >= qp.minlon && p.lon <= qp.maxlon) {
+				if (p.getLat() >= qp.minlat && p.getLat() <= qp.maxlat && p.getLon() >= qp.minlon && p.getLon() <= qp.maxlon) {
 					isOnePointIn = true;
 				}
 			}
@@ -107,15 +110,15 @@ public class OsmGpxWriteContext {
 	}
 	
 
-	public void writeTrack(OsmGpxFile gpxInfo, Map<String, String> extraTrackTags, GPXFile gpxFile, GPXTrackAnalysis analysis,
+	public void writeTrack(OsmGpxFile gpxInfo, Map<String, String> extraTrackTags, GpxFile gpxFile, GpxTrackAnalysis analysis,
 			String routeIdPrefix)
 			throws IOException, SQLException {
 		Map<String, String> gpxTrackTags = new LinkedHashMap<String, String>();
 		if (qp.details < QueryParams.DETAILS_TRACKS) {
 			boolean validTrack = false;
-			for (Track t : gpxFile.tracks) {
-				for (TrkSegment s : t.segments) {
-					if (s.points.isEmpty()) {
+			for (Track t : gpxFile.getTracks()) {
+				for (TrkSegment s : t.getSegments()) {
+					if (s.getPoints().isEmpty()) {
 						continue;
 					}
 					if (!validatedTrackSegment(s)) {
@@ -129,23 +132,23 @@ public class OsmGpxWriteContext {
 				serializer.attribute(null, "id", id-- + "");
 				serializer.attribute(null, "action", "modify");
 				serializer.attribute(null, "version", "1");
-				serializer.attribute(null, "lat", latLonFormat.format(gpxFile.findPointToShow().lat));
-				serializer.attribute(null, "lon", latLonFormat.format(gpxFile.findPointToShow().lon));
+				serializer.attribute(null, "lat", latLonFormat.format(gpxFile.findPointToShow().getLat()));
+				serializer.attribute(null, "lon", latLonFormat.format(gpxFile.findPointToShow().getLon()));
 				tagValue(serializer, "route", "segment");
 				tagValue(serializer, "route_type", "track");
 				tagValue(serializer, "route_radius", gpxFile.getOuterRadius());
 				addGenericTags(gpxTrackTags, null);
 				addGpxInfoTags(gpxTrackTags, gpxInfo, routeIdPrefix);
-				addExtensionsTags(gpxTrackTags, gpxFile.extensions);
+				addExtensionsTags(gpxTrackTags, gpxFile.getExtensions());
 				addPointGroupsTags(gpxTrackTags, gpxFile.getPointsGroups());
 				addAnalysisTags(gpxTrackTags, analysis);
 				serializeTags(extraTrackTags, gpxTrackTags);
 				serializer.endTag(null, "node");
 			}
 		} else {
-			for (Track t : gpxFile.tracks) {
-				for (TrkSegment s : t.segments) {
-					if (s.points.isEmpty()) {
+			for (Track t : gpxFile.getTracks()) {
+				for (TrkSegment s : t.getSegments()) {
+					if (s.getPoints().isEmpty()) {
 						continue;
 					}
 					if (!validatedTrackSegment(s)) {
@@ -153,12 +156,12 @@ public class OsmGpxWriteContext {
 					}
 					segments++;
 					long idStart = id;
-					double dlon = s.points.get(0).lon;
-					double dlat = s.points.get(0).lat;
-					QuadRect qr = new QuadRect(dlon, dlat, dlon, dlat);
-					for (WptPt p : s.points) {
+					double dlon = s.getPoints().get(0).getLon();
+					double dlat = s.getPoints().get(0).getLat();
+					KQuadRect qr = new KQuadRect(dlon, dlat, dlon, dlat);
+					for (WptPt p : s.getPoints()) {
 						long nid = id--;
-						GPXUtilities.updateQR(qr, p, dlat, dlon);
+						GpxUtilities.INSTANCE.updateQR(qr, p, dlat, dlon);
 						writePoint(nid, p, null, null, null);
 					}
 					long endid = id;
@@ -174,12 +177,12 @@ public class OsmGpxWriteContext {
 					}
 					tagValue(serializer, "route", "segment");
 					tagValue(serializer, "route_type", "track");
-					int radius = (int) MapUtils.getDistance(qr.bottom, qr.left, qr.top, qr.right);
-					tagValue(serializer, "route_radius", MapUtils.convertDistToChar(radius, GPXUtilities.TRAVEL_GPX_CONVERT_FIRST_LETTER, GPXUtilities.TRAVEL_GPX_CONVERT_FIRST_DIST,
-							GPXUtilities.TRAVEL_GPX_CONVERT_MULT_1, GPXUtilities.TRAVEL_GPX_CONVERT_MULT_2));
+					int radius = (int) MapUtils.getDistance(qr.getBottom(), qr.getLeft(), qr.getTop(), qr.getRight());
+					tagValue(serializer, "route_radius", MapUtils.convertDistToChar(radius, GpxUtilities.TRAVEL_GPX_CONVERT_FIRST_LETTER, GpxUtilities.TRAVEL_GPX_CONVERT_FIRST_DIST,
+							GpxUtilities.TRAVEL_GPX_CONVERT_MULT_1, GpxUtilities.TRAVEL_GPX_CONVERT_MULT_2));
 					addGenericTags(gpxTrackTags, t);
 					addGpxInfoTags(gpxTrackTags, gpxInfo, routeIdPrefix);
-					addExtensionsTags(gpxTrackTags, gpxFile.extensions);
+					addExtensionsTags(gpxTrackTags, gpxFile.getExtensions());
 					addPointGroupsTags(gpxTrackTags, gpxFile.getPointsGroups());
 					addAnalysisTags(gpxTrackTags, analysis);
 					addElevationTags(gpxTrackTags, s);
@@ -188,7 +191,7 @@ public class OsmGpxWriteContext {
 				}
 			}
 
-			for (WptPt p : gpxFile.getPoints()) {
+			for (WptPt p : gpxFile.getPointsList()) {
 				long nid = id--;
 				if (gpxInfo != null) {
 					writePoint(nid, p, "point", routeIdPrefix + gpxInfo.id, gpxInfo.name);
@@ -198,16 +201,16 @@ public class OsmGpxWriteContext {
 		tracks++;
 	}
 
-	private void addPointGroupsTags(Map<String, String> gpxTrackTags, Map<String, GPXUtilities.PointsGroup> pointsGroups) {
+	private void addPointGroupsTags(Map<String, String> gpxTrackTags, Map<String, PointsGroup> pointsGroups) {
 		List<String> pgNames = new ArrayList<>();
 		List<String> pgIcons = new ArrayList<>();
 		List<String> pgColors = new ArrayList<>();
 		List<String> pgBackgrounds = new ArrayList<>();
 		for (String name : pointsGroups.keySet()) {
 			pgNames.add(name);
-			pgIcons.add(pointsGroups.get(name).iconName);
-			pgBackgrounds.add(pointsGroups.get(name).backgroundType);
-			pgColors.add(Algorithms.colorToString(pointsGroups.get(name).color));
+			pgIcons.add(pointsGroups.get(name).getIconName());
+			pgBackgrounds.add(pointsGroups.get(name).getBackgroundType());
+			pgColors.add(KAlgorithms.INSTANCE.colorToString(pointsGroups.get(name).getColor()));
 		}
 		final String delimiter = OBF_POINTS_GROUPS_DELIMITER;
 		gpxTrackTags.put(OBF_POINTS_GROUPS_NAMES, String.join(delimiter, pgNames));
@@ -235,9 +238,9 @@ public class OsmGpxWriteContext {
 
 	private void addElevationTags(Map<String, String> gpxTrackTags, TrkSegment s) {
 		IndexHeightData.WayGeneralStats wgs = new IndexHeightData.WayGeneralStats();
-		for (WptPt p : s.points) {
-			wgs.altitudes.add(p.ele);
-			wgs.dists.add(p.distance);
+		for (WptPt p : s.getPoints()) {
+			wgs.altitudes.add(p.getEle());
+			wgs.dists.add(p.getDistance());
 		}
 		IndexHeightData.calculateEleStats(wgs, (int) DIST_STEP);
 		if (wgs.eleCount > 0) {
@@ -247,8 +250,8 @@ public class OsmGpxWriteContext {
 			gpxTrackTags.put("avg_ele__start", String.valueOf((int) (wgs.sumEle / wgs.eleCount) - st));
 			gpxTrackTags.put("min_ele__start", String.valueOf((int) wgs.minEle - st));
 			gpxTrackTags.put("max_ele__start", String.valueOf((int) wgs.maxEle - st));
-			gpxTrackTags.putIfAbsent("diff_ele_up", String.valueOf((int) wgs.up)); // prefer GPXTrackAnalysis
-			gpxTrackTags.putIfAbsent("diff_ele_down", String.valueOf((int) wgs.down)); // prefer GPXTrackAnalysis
+			gpxTrackTags.putIfAbsent("diff_ele_up", String.valueOf((int) wgs.up)); // prefer GpxTrackAnalysis
+			gpxTrackTags.putIfAbsent("diff_ele_down", String.valueOf((int) wgs.down)); // prefer GpxTrackAnalysis
 			gpxTrackTags.put("ele_graph", MapAlgorithms.encodeIntHeightArrayGraph(wgs.step, wgs.altIncs, MAX_GRAPH_SKIP_POINTS_BITS));
 		}
 	}
@@ -275,11 +278,11 @@ public class OsmGpxWriteContext {
 
 	private void addGenericTags(Map<String, String> gpxTrackTags, Track p) throws IOException {
 		if (p != null) {
-			if (!Algorithms.isEmpty(p.name)) {
-				gpxTrackTags.put("name", p.name);
+			if (!Algorithms.isEmpty(p.getName())) {
+				gpxTrackTags.put("name", p.getName());
 			}
-			if (!Algorithms.isEmpty(p.desc)) {
-				gpxTrackTags.put("description", p.desc);
+			if (!Algorithms.isEmpty(p.getDesc())) {
+				gpxTrackTags.put("description", p.getDesc());
 			}
 			int color = p.getColor(0);
 			if (color != 0) {
@@ -313,13 +316,13 @@ public class OsmGpxWriteContext {
 		}
 	}
 
-	private void addAnalysisTags(Map<String, String> gpxTrackTags, GPXTrackAnalysis analysis) throws IOException {
+	private void addAnalysisTags(Map<String, String> gpxTrackTags, GpxTrackAnalysis analysis) throws IOException {
 		gpxTrackTags.put("distance", latLonFormat.format(analysis.getTotalDistance()));
 		if (analysis.isTimeSpecified()) {
 			gpxTrackTags.put("time_span", analysis.getTimeSpan() + "");
-			gpxTrackTags.put("time_span_no_gaps", analysis.timeSpanWithoutGaps + "");
+			gpxTrackTags.put("time_span_no_gaps", analysis.getTimeSpanWithoutGaps() + "");
 			gpxTrackTags.put("time_moving", analysis.getTimeMoving() + "");
-			gpxTrackTags.put("time_moving_no_gaps", analysis.timeMovingWithoutGaps + "");
+			gpxTrackTags.put("time_moving_no_gaps", analysis.getTimeMovingWithoutGaps() + "");
 		}
 		if (analysis.hasElevationData()) {
 			gpxTrackTags.put("avg_ele", latLonFormat.format(analysis.getAvgElevation()));
@@ -337,8 +340,8 @@ public class OsmGpxWriteContext {
 	
 	private void writePoint(long id, WptPt p, String routeType, String routeId, String routeName) throws IOException {
 		serializer.startTag(null, "node");
-		serializer.attribute(null, "lat", latLonFormat.format(p.lat));
-		serializer.attribute(null, "lon", latLonFormat.format(p.lon));
+		serializer.attribute(null, "lat", latLonFormat.format(p.getLat()));
+		serializer.attribute(null, "lon", latLonFormat.format(p.getLon()));
 		serializer.attribute(null, "id", id + "");
 		serializer.attribute(null, "action", "modify");
 		serializer.attribute(null, "version", "1");
@@ -348,21 +351,21 @@ public class OsmGpxWriteContext {
 			tagValue(serializer, "route_id", routeId);
 			tagValue(serializer, "route_name", routeName);
 		}
-		if (!Algorithms.isEmpty(p.name)) {
-			tagValue(serializer, "name", p.name);
+		if (!Algorithms.isEmpty(p.getName())) {
+			tagValue(serializer, "name", p.getName());
 		}
-		if (!Algorithms.isEmpty(p.desc)) {
-			tagValue(serializer, "description", p.desc);
+		if (!Algorithms.isEmpty(p.getDesc())) {
+			tagValue(serializer, "description", p.getDesc());
 		}
-		if (!Algorithms.isEmpty(p.category)) {
-			tagValue(serializer, "category", p.category);
-			tagValue(serializer, OBF_POINTS_GROUPS_CATEGORY, p.category);
+		if (!Algorithms.isEmpty(p.getCategory())) {
+			tagValue(serializer, "category", p.getCategory());
+			tagValue(serializer, OBF_POINTS_GROUPS_CATEGORY, p.getCategory());
 		}
-		if (!Algorithms.isEmpty(p.comment)) {
-			tagValue(serializer, "note", p.comment);
+		if (!Algorithms.isEmpty(p.getComment())) {
+			tagValue(serializer, "note", p.getComment());
 		}
-		if (!Algorithms.isEmpty(p.link)) {
-			tagValue(serializer, "url", p.link);
+		if (!Algorithms.isEmpty(p.getLink())) {
+			tagValue(serializer, "url", p.getLink());
 		}
 		if (!Algorithms.isEmpty(p.getIconName())) {
 			tagValue(serializer, "gpx_icon", p.getIconName());
@@ -376,14 +379,14 @@ public class OsmGpxWriteContext {
 			tagValue(serializer, "colour_int", Algorithms.colorToString(color));
 		}
 		if (qp.details >= QueryParams.DETAILS_ELE_SPEED) {
-			if (!Double.isNaN(p.ele)) {
-				tagValue(serializer, "ele", latLonFormat.format(p.ele));
+			if (!Double.isNaN(p.getEle())) {
+				tagValue(serializer, "ele", latLonFormat.format(p.getEle()));
 			}
-			if (!Double.isNaN(p.speed) && p.speed > 0) {
-				tagValue(serializer, "speed", latLonFormat.format(p.speed));
+			if (!Double.isNaN(p.getSpeed()) && p.getSpeed() > 0) {
+				tagValue(serializer, "speed", latLonFormat.format(p.getSpeed()));
 			}
-			if (!Double.isNaN(p.hdop)) {
-				tagValue(serializer, "hdop", latLonFormat.format(p.hdop));
+			if (!Double.isNaN(p.getHdop())) {
+				tagValue(serializer, "hdop", latLonFormat.format(p.getHdop()));
 			}
 		}
 		serializer.endTag(null, "node");
@@ -399,19 +402,19 @@ public class OsmGpxWriteContext {
 		serializer.endTag(null, "tag");
 	}
 	
-	public File writeObf(Map<String, GPXFile> gpxFiles, List<File> files, File tmpFolder, String fileName, File targetObf) throws IOException,
+	public File writeObf(Map<String, GpxFile> gpxFiles, List<KFile> files, File tmpFolder, String fileName, File targetObf) throws IOException,
 			SQLException, InterruptedException, XmlPullParserException {
 		
 		startDocument();
 		if (gpxFiles != null) {
-			for (Entry<String, GPXFile> entry : gpxFiles.entrySet()) {
-				GPXFile gpxFile = entry.getValue();
+			for (Entry<String, GpxFile> entry : gpxFiles.entrySet()) {
+				GpxFile gpxFile = entry.getValue();
 				writeFile(gpxFile, entry.getKey());
 			}
 		} else if (files != null) {
-			for (File gf : files) {
-				GPXFile gpxFile = GPXUtilities.loadGPXFile(gf, null, false);
-				writeFile(gpxFile, gf.getName());
+			for (KFile gf : files) {
+				GpxFile gpxFile = GpxUtilities.INSTANCE.loadGpxFile(gf, null, false);
+				writeFile(gpxFile, gf.name());
 			}
 		}
 		endDocument();
@@ -439,16 +442,16 @@ public class OsmGpxWriteContext {
 		return targetObf;
 	}
 	
-	private void writeFile(GPXFile gpxFile, String fileName) throws SQLException, IOException {
-		GPXTrackAnalysis analysis = gpxFile.getAnalysis(gpxFile.modifiedTime);
+	private void writeFile(GpxFile gpxFile, String fileName) throws SQLException, IOException {
+		GpxTrackAnalysis analysis = gpxFile.getAnalysis(gpxFile.getModifiedTime());
 		OsmGpxFile file = new OsmGpxFile();
 		String name = fileName;
 		if (name.lastIndexOf('.') != -1) {
 			name = name.substring(0, name.lastIndexOf('.'));
 		}
 		file.name = name;
-		file.id = gpxFile.modifiedTime / 1000;
-		file.timestamp = new Date(gpxFile.modifiedTime);
+		file.id = gpxFile.getModifiedTime() / 1000;
+		file.timestamp = new Date(gpxFile.getModifiedTime());
 		file.description = "";
 		file.tags = new String[0];
 		writeTrack(file, null, gpxFile, analysis, "GPX");
@@ -457,22 +460,22 @@ public class OsmGpxWriteContext {
 	public static void generateObfFromGpx(List<String> subArgs) throws IOException, SQLException,
 			XmlPullParserException, InterruptedException {
 		if (subArgs.size() != 0) {
-			File file = new File(subArgs.get(0));
-			if (file.isDirectory() || file.getName().endsWith(GPX_FILE_EXT) || file.getName().endsWith(".gpx.gz")) {
+			KFile file = new KFile(subArgs.get(0));
+			if (file.isDirectory() || file.name().endsWith(GPX_FILE_EXT) || file.name().endsWith(".gpx.gz")) {
 				OsmGpxWriteContext.QueryParams qp = new OsmGpxWriteContext.QueryParams();
-				qp.osmFile = File.createTempFile(Algorithms.getFileNameWithoutExtension(file), ".osm");
+				qp.osmFile = File.createTempFile(KAlgorithms.INSTANCE.getFileNameWithoutExtension(file), ".osm");
 				OsmGpxWriteContext ctx = new OsmGpxWriteContext(qp);
-				File dir = file.isDirectory() ? file : file.getParentFile();
+				File dir = new File(file.isDirectory() ? file.name() : file.parent().name());
 				File tmpFolder = new File(dir, String.valueOf(System.currentTimeMillis()));
-				File targetObf = new File(dir, Algorithms.getFileNameWithoutExtension(file) + BINARY_MAP_INDEX_EXT);
-				List<File> files = new ArrayList<>();
+				File targetObf = new File(dir, KAlgorithms.INSTANCE.getFileNameWithoutExtension(file) + BINARY_MAP_INDEX_EXT);
+				List<KFile> files = new ArrayList<>();
 				if (file.isDirectory()) {
 					files = Arrays.asList(Objects.requireNonNull(file.listFiles()));
 				} else {
 					files.add(file);
 				}
 				if (!files.isEmpty()) {
-					ctx.writeObf(null, files, tmpFolder, Algorithms.getFileNameWithoutExtension(file), targetObf);
+					ctx.writeObf(null, files, tmpFolder, KAlgorithms.INSTANCE.getFileNameWithoutExtension(file), targetObf);
 				}
 				if (!qp.osmFile.delete()) {
 					qp.osmFile.deleteOnExit();

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 
 import net.osmand.router.*;
+import net.osmand.shared.gpx.GpxFile;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
@@ -1670,7 +1671,7 @@ public class OsmAndMapsService {
 		return osmandRegions;
 	}
 
-	public File getObf(Map<String, GPXFile> files)
+	public File getObf(Map<String, GpxFile> files)
 			throws IOException, SQLException, XmlPullParserException, InterruptedException {
 		File tmpOsm = File.createTempFile("gpx_obf", ".osm.gz");
 		File tmpFolder = new File(tmpOsm.getParentFile(), String.valueOf(System.currentTimeMillis()));

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/user/MapApiController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/user/MapApiController.java
@@ -2,6 +2,9 @@ package net.osmand.server.controllers.user;
 
 import java.io.*;
 
+import okio.GzipSource;
+import okio.Okio;
+
 import static net.osmand.server.api.services.FavoriteService.FILE_TYPE_FAVOURITES;
 import static net.osmand.server.api.services.UserdataService.*;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
@@ -29,6 +32,8 @@ import net.osmand.server.api.repo.PremiumUsersRepository;
 import net.osmand.server.api.services.*;
 import net.osmand.server.controllers.pub.UserSessionResources;
 import net.osmand.server.utils.WebGpxParser;
+import net.osmand.shared.gpx.GpxFile;
+import net.osmand.shared.gpx.GpxUtilities;
 import net.osmand.util.Algorithms;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.commons.logging.Log;
@@ -628,12 +633,12 @@ public class MapApiController {
 		FileInputStream fis = null;
 		File targetObf = null;
 		try (OutputStream os = response.getOutputStream()) {
-			Map<String, GPXFile> files = new HashMap<>();
+			Map<String, GpxFile> files = new HashMap<>();
 			for (String name : names) {
 				UserFile userFile = userdataService.getUserFile(name, "GPX", null, dev);
 				if (userFile != null) {
 					is = userdataService.getInputStream(dev, userFile);
-					GPXFile file = GPXUtilities.loadGPXFile(new GZIPInputStream(is), null, false);
+					GpxFile file = GpxUtilities.INSTANCE.loadGpxFile(null, new GzipSource(Okio.source(is)), null, false);
 					files.put(name, file);
 				}
 			}

--- a/java-tools/OsmAndServerUtilities/build.gradle
+++ b/java-tools/OsmAndServerUtilities/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 
 	implementation project(':OsmAndMapCreatorUtilities')
 	implementation project(':OsmAnd-java')
+	implementation project(path:':OsmAnd-shared', configuration : 'jvmPublicConfig')
 
 	implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
 	implementation 'com.google.code.findbugs:jsr305:3.0.2'


### PR DESCRIPTION
Using GpxFile, GpxUtilities, GpxTrackAnalysis from Kotlin lib:

DownloadOsmGPX 100% (tested on corresponding Jenkins job)
OsmGpxWriteContext 100% (tested on convert-gpx-to-obf utility)

MapApiController minimally
OsmAndMapsService minimally
