### PR TITLE
Hotfix StorageService.handleException %s String.format error

### DIFF
--- a/java-tools/.gitignore
+++ b/java-tools/.gitignore
@@ -15,4 +15,5 @@ build/
 *.iml
 regions.ocbf
 .attach_*
+OsmAndServer/src/main/resources/colorPalette.zip
 OsmAndMapCreatorUtilities/src/main/resources/page.txt

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/StorageService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/StorageService.java
@@ -257,7 +257,8 @@ public class StorageService {
 	}
 
 	private void handleException(StorageType st, String req, String fld, String fileName, SdkClientException e) {
-		LOGGER.warn(String.format("Request %s to file %s - %s has failed: %s ", req, fld, fileName));
+		LOGGER.warn(String.format(
+				"StorageError: request %s to file %s - %s has failed (%s)", req, fld, fileName, e.getMessage()));
 		if (e.getCause() instanceof org.apache.http.conn.ConnectionPoolTimeoutException) {
 			if (System.currentTimeMillis() - reconnectTime > 60 * 1000) {
 				st.s3Conn = st.s3ConnBuilder.build();


### PR DESCRIPTION
```
java.util.MissingFormatArgumentException: Format specifier '%s'
        at java.base/java.util.Formatter.format(Formatter.java:2688)
        at java.base/java.util.Formatter.format(Formatter.java:2625)
        at java.base/java.lang.String.format(String.java:4145)
        at net.osmand.server.api.services.StorageService.handleException(StorageService.java:260)
        at net.osmand.server.api.services.StorageService.getFileInputStream(StorageService.java:231)
        at net.osmand.server.api.services.UserdataService.getInputStream(UserdataService.java:699)
        at net.osmand.server.api.services.UserdataService$$FastClassBySpringCGLIB$$29bff6a0.invoke(<generated>)
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
        at org.springframework.aop.framework.CglibAopProxy.invokeMethod(CglibAopProxy.java:386)
        at org.springframework.aop.framework.CglibAopProxy.access$000(CglibAopProxy.java:85)
```