### PR TITLE
Parse MapCreator URL (aosmc=true instead of =yes)

### DIFF
--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapPanel.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapPanel.java
@@ -593,7 +593,7 @@ public class MapPanel extends JPanel implements IMapDownloaderCallback {
 
 	protected void downloadDiffs(Graphics2D g, MapDiff md) {
 		try {
-			String url = "https://download.osmand.net/check_live?aosmc=true&self=true&timestamp=" + md.timestamp +
+			String url = "https://download.osmand.net/check_live?aosmc=yes&timestamp=" + md.timestamp +
 					"&file=" + URLEncoder.encode(md.baseName, StandardCharsets.UTF_8.toString());
 			System.out.println("Loading " + url);
 			HttpURLConnection conn = NetworkUtils.getHttpURLConnection(url);
@@ -616,7 +616,7 @@ public class MapPanel extends JPanel implements IMapDownloaderCallback {
 				long time = updateFiles.get(file);
 				File targetFile = new File(dir, file.substring(0, file.length() - 3));
 				if(!targetFile.exists() || targetFile.lastModified() != time) {
-					String nurl = "https://download.osmand.net/download?aosmc=true&self=true&" + md.timestamp + "&file=" + URLEncoder.encode(file, StandardCharsets.UTF_8.toString());
+					String nurl = "https://download.osmand.net/download?aosmc=yes&" + md.timestamp + "&file=" + URLEncoder.encode(file, StandardCharsets.UTF_8.toString());
 					System.out.println("Loading " + nurl);
 					HttpURLConnection c = NetworkUtils.getHttpURLConnection(nurl);
 					GZIPInputStream gzip = new GZIPInputStream(c.getInputStream());

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/DownloadIndexController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/DownloadIndexController.java
@@ -198,7 +198,7 @@ public class DownloadIndexController {
 	}
 
 	private boolean isContainAndEqual(String param, MultiValueMap<String, String> params) {
-		return isContainAndEqual(param, "yes", params);
+		return isContainAndEqual(param, "yes", params) || isContainAndEqual(param, "true", params);
 	}
 
 	


### PR DESCRIPTION
1) Fix wrong server selection for URL such as `https://download.osmand.net/download?aosmc=true&file=Thailand_asia_24_12_00.obf.gz`

`aosmc=true` is incorrect and it should be set to "yes" to select right servers in load balancer code

2) Additionally, the URL is changed to correct (**possibly, the 2nd commit is enough to fix issue**)