### PR TITLE
Allow multiple from/to members in no_entry/no_exit relations

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexRouteCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexRouteCreator.java
@@ -623,10 +623,10 @@ public class IndexRouteCreator extends AbstractIndexPartCreator {
 					type = MapRenderingTypes.RESTRICTION_ONLY_STRAIGHT_ON;
 				}
 				if (type != -1) {
-					ctx.loadEntityRelation((Relation) e);
-					Collection<RelationMember> fromL = ((Relation) e).getMembers("from"); //$NON-NLS-1$
-					Collection<RelationMember> toL = ((Relation) e).getMembers("to"); //$NON-NLS-1$
-					Collection<RelationMember> viaL = ((Relation) e).getMembers("via"); //$NON-NLS-1$
+					ctx.loadEntityRelation(r);
+					Collection<RelationMember> fromL = r.getMembers("from"); //$NON-NLS-1$
+					Collection<RelationMember> toL = r.getMembers("to"); //$NON-NLS-1$
+					Collection<RelationMember> viaL = r.getMembers("via"); //$NON-NLS-1$
 					if (!fromL.isEmpty() && !toL.isEmpty()) {
 						RelationMember from = fromL.iterator().next();
 						RelationMember to = toL.iterator().next();

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexRouteCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexRouteCreator.java
@@ -591,10 +591,10 @@ public class IndexRouteCreator extends AbstractIndexPartCreator {
 			String val = e.getTag("restriction"); //$NON-NLS-1$
 			if (val != null) {
 				Relation r = (Relation) e;
-				List<RelationMember> lfrom = r.getMembers("from");
-				List<RelationMember> lto = r.getMembers("to");
-				if("no_u_turn".equalsIgnoreCase(val)) {
-					if(lfrom.size() == 1 && lto.size() == 1 &&
+				if ("no_u_turn".equalsIgnoreCase(val)) { //$NON-NLS-1$
+					List<RelationMember> lfrom = r.getMembers("from"); //$NON-NLS-1$
+					List<RelationMember> lto = r.getMembers("to"); //$NON-NLS-1$
+					if (lfrom.size() == 1 && lto.size() == 1 &&
 							lfrom.get(0).getEntityId().equals(lto.get(0).getEntityId())) {
 						// don't index such roads - can't go through issue https://www.openstreetmap.org/way/338099991#map=17/46.86699/-0.20473
 						return;


### PR DESCRIPTION
This fixes osmandapp/OsmAnd#21855 by looping over the list of members and adding multiple `RestrictionInfo` to the corresponding ways if that is valid for the given restriction type. For relations that only allow one way for each role, it keeps the current behavior of using only the first one.

I tested it in some scenarios and it seems to work correctly.

While I was at it, i also added two small commits to improve the code of the function a little bit.