### PR TITLE
Fix city duplication by set admin_centre for relation amenity

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
@@ -162,7 +162,6 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 		etags = renderingTypes.transformTags(etags, EntityType.valueOf(e), EntityConvertApplyType.POI);
 		tempAmenityList = EntityParser.parseAmenities(poiTypes, e, etags, tempAmenityList);
 		if (!tempAmenityList.isEmpty() && poiPreparedStatement != null) {
-            LatLon climbingCenter = retrieveClimbingCenter(e, ctx);
 			if (e instanceof Relation) {
 				ctx.loadEntityRelation((Relation) e);
 			}
@@ -184,6 +183,16 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 					}
 				}
 			}
+			LatLon center = null;
+			if (e instanceof Relation relation) {
+				List<Entity> entities = relation.getMemberEntities("admin_centre");
+				if (entities.size() ==  1) {
+					center = entities.get(0).getLatLon();
+				} else {
+					center = retrieveClimbingCenter(e, ctx);
+				}
+			}
+
 			for (Amenity a : tempAmenityList) {
 				if (icc.basemap) {
 					PoiType st = a.getType().getPoiTypeByKeyName(a.getSubType());
@@ -191,8 +200,8 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 						continue;
 					}
 				}
-                if (climbingCenter != null) {
-                    a.setLocation(climbingCenter);
+                if (center != null) {
+                    a.setLocation(center);
                 }
 				// do not add that check because it is too much printing for batch creation
 				// by statistic < 1% creates maps manually


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd/issues/21120#issuecomment-2685148499

https://www.openstreetmap.org/relation/62422 (relation Berlin)
https://www.openstreetmap.org/node/240109189 (city Berlin)

Map details:
```administrative: city Berlin Lat 52.510887 Lon 13.398932 osmid=240109189```
```administrative: city Berlin Lat 52.50609 Lon 13.429724 osmid=2199087175680```