### PR TITLE
Ignore name: with no lang prefixes

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexAddressCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexAddressCreator.java
@@ -32,6 +32,7 @@ import net.osmand.data.MultipolygonBuilder;
 import net.osmand.data.QuadRect;
 import net.osmand.data.Street;
 import net.osmand.obf.preparation.DBStreetDAO.SimpleStreet;
+import net.osmand.osm.MapRenderingTypes;
 import net.osmand.osm.edit.Entity;
 import net.osmand.osm.edit.EntityParser;
 import net.osmand.osm.edit.Node;
@@ -989,10 +990,14 @@ public class IndexAddressCreator extends AbstractIndexPartCreator {
 
 	private Map<String, String> getOtherNames(Entity e) {
 		Map<String, String> m = null;
+        List<String> languages = Arrays.asList(MapRenderingTypes.langs);
 		for (String t : e.getTagKeySet()) {
 			String prefix =  null;
 			if(t.startsWith("name:")) {
-				prefix = "name:";
+                String lang = t.substring(5);
+                if (languages.contains(lang)) {
+                    prefix = "name:";
+                }
 			} else if(t.startsWith("old_name")){
 				prefix = "";
 			} else if(t.startsWith("alt_name")){


### PR DESCRIPTION
Object with _name:etymology:wikipedia=uk:Софійський собор (Київ)_
[Софіївська вулиця (172384581)](https://www.openstreetmap.org/way/172384581)

Related task: [Additionally consider alt_name in the search of objects](https://github.com/osmandapp/OsmAnd/issues/22089)


Before / after map generation (Kyiv):
<img src="https://github.com/user-attachments/assets/da7dde07-164c-4730-99da-5382ef477614" width="350" /> <img src="https://github.com/user-attachments/assets/a48ea458-8e8a-4a50-b98f-84abaebf0407" width="350" />
