### PR TITLE
Hotfix "Azores 100% (35905078875).jpg" and so on

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/WikiService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/WikiService.java
@@ -551,7 +551,13 @@ public class WikiService {
 	}
 	
 	private String createImageUrl(String imageTitle) {
-		String[] hash = getHash(URLDecoder.decode(imageTitle, StandardCharsets.UTF_8));
+		try {
+			imageTitle = URLDecoder.decode(imageTitle, StandardCharsets.UTF_8);
+		} catch (IllegalArgumentException e) {
+			log.warn("imageTitle decode failed: " + imageTitle, e);
+		}
+		String[] hash = getHash(imageTitle);
+		imageTitle = URLEncoder.encode(imageTitle, StandardCharsets.UTF_8);
 		if (FILE_URL_TO_USE == 0) {
 			return WIKIMEDIA_COMMON_SPECIAL_FILE_PATH + imageTitle;
 		} else if (FILE_URL_TO_USE == 1) {


### PR DESCRIPTION
should fix

```
2025-09-04 11:03:18.151 ERROR [http-nio-127.0.0.1-8090-exec-3]: URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 0 in: ".p"
java.lang.IllegalArgumentException: URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 0 in: ".p"
        at java.base/java.net.URLDecoder.decode(URLDecoder.java:237)
        at net.osmand.server.api.services.WikiService.createImageUrl(WikiService.java:554)
        at net.osmand.server.api.services.WikiService.lambda$processWikiImagesWithDetails$13(WikiService.java:538)
        at org.springframework.jdbc.core.JdbcTemplate$RowCallbackHandlerResultSetExtractor.extractData(JdbcTemplate.java:1688)
        at org.springframework.jdbc.core.JdbcTemplate$1.doInPreparedStatement(JdbcTemplate.java:723)
        at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:651)
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:713)
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:744)
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:773)
        at net.osmand.server.api.services.WikiService.processImageQuery(WikiService.java:566)
2025-09-04 11:03:18.152 ERROR [http-nio-127.0.0.1-8090-exec-3]: Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: java.lang.IllegalArgumentException: URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 0 in: ".p"] with root cause
java.lang.IllegalArgumentException: URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 0 in: ".p"
        at java.base/java.net.URLDecoder.decode(URLDecoder.java:237)
        at net.osmand.server.api.services.WikiService.createImageUrl(WikiService.java:554)
        at net.osmand.server.api.services.WikiService.lambda$processWikiImagesWithDetails$13(WikiService.java:538)
        at org.springframework.jdbc.core.JdbcTemplate$RowCallbackHandlerResultSetExtractor.extractData(JdbcTemplate.java:1688)
        at org.springframework.jdbc.core.JdbcTemplate$1.doInPreparedStatement(JdbcTemplate.java:723)
        at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:651)
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:713)
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:744)
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:773)
        at net.osmand.server.api.services.WikiService.processImageQuery(WikiService.java:566)
```