### PR TITLE
empty-suffix-dictionary-fix

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/BinaryMapIndexWriter.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/BinaryMapIndexWriter.java
@@ -1013,8 +1013,12 @@ public class BinaryMapIndexWriter {
 			List<MapObject> objects = new ArrayList<>(indexEntry.getObjects());
 			SuffixDictionary<MapObject> suffixDictionary = nameIndexBuildSuffixDictionary(entry.getKey(), objects,
 					indexEntry::getTokens);
-			for (SuffixEntry dictionaryEntry : suffixDictionary.dictionaryEntries) {
-				builder.addSuffixesDictionary(dictionaryEntry.encodedSuffix());
+			if (suffixDictionary.dictionaryEntries.isEmpty()) {
+				builder.addSuffixesDictionary(EMPTY_SUFFIX_DICTIONARY_SENTINEL);
+			} else {
+				for (SuffixEntry dictionaryEntry : suffixDictionary.dictionaryEntries) {
+					builder.addSuffixesDictionary(dictionaryEntry.encodedSuffix());
+				}
 			}
 			for (MapObject o : objects) {
 				AddressNameIndexDataAtom.Builder atom = AddressNameIndexDataAtom.newBuilder();
@@ -1759,7 +1763,7 @@ public class BinaryMapIndexWriter {
 			SuffixDictionary<PoiTileBox> suffixDictionary = nameIndexBuildSuffixDictionary(e.getKey(), tileBoxes,
 					box -> box.tokens);
 			if (suffixDictionary.dictionaryEntries.isEmpty()) {
-				builder.addSuffixesDictionary(EMPTY_POI_SUFFIX_DICTIONARY_SENTINEL);
+				builder.addSuffixesDictionary(EMPTY_SUFFIX_DICTIONARY_SENTINEL);
 			} else {
 				for (SuffixEntry dictionaryEntry : suffixDictionary.dictionaryEntries) {
 					builder.addSuffixesDictionary(dictionaryEntry.encodedSuffix());


### PR DESCRIPTION
fix empty suffix dictionary for short prefixes.

Resulting behavior:
State 1. suffixDictionary == null for old version OBF to skip suffix filtering and allow all offsets.
State 2. suffixDictionary.isEmpty(). Prefix is normal and dictionary is present but no suffixes, no objects pass suffix filtering.
State 3. suffixDictionary.size() == 1 and suffixDictionary.get(0).isEmpty(). For short prefix use singleton dictionary [""] for normal filtering to allow loading of all offsets in that matched block.
State 4. !suffixDictionary.isEmpty(). Non-empty dictionary with normal entries, standard suffix-bitset filtering.