### PR TITLE
Pt-prioritize-platform-instead-of-stop-for-routes-7

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexTransportCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexTransportCreator.java
@@ -16,6 +16,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,6 +59,8 @@ import rtree.RTreeException;
 import rtree.RTreeInsertException;
 import rtree.Rect;
 
+import static net.osmand.data.TransportStop.CONNECTED_STOP_IDS;
+
 
 public class IndexTransportCreator extends AbstractIndexPartCreator {
 
@@ -71,9 +74,12 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 	private PreparedStatement transRouteStat;
 	private PreparedStatement transRouteStopsStat;
 	private PreparedStatement transStopsStat;
+	private PreparedStatement updateStopStat;
 	private PreparedStatement transRouteGeometryStat;
 	private RTree transportStopsTree;
 	private Map<Long, Relation> masterRoutes = new HashMap<Long, Relation>();
+	private Map<EntityId, Set<Long>> connectedStopIds = new LinkedHashMap<EntityId, Set<Long>>();
+	private Map<Long, TransportStop> updatedPlatformStops = new LinkedHashMap<Long, TransportStop>();
 	private Connection gtfsConnection;
 
 	private static final long TEST_ROUTE_ID_MISSING_STOPS = 192037l;
@@ -351,10 +357,12 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 		transRouteStat = conn.prepareStatement("insert into transport_route(id, type, operator, ref, name, name_en, dist, color) values(?, ?, ?, ?, ?, ?, ?, ?)");
 		transRouteStopsStat = conn.prepareStatement("insert into transport_route_stop(route, stop, ord) values(?, ?, ?)");
 		transStopsStat = conn.prepareStatement("insert into transport_stop(id, latitude, longitude, name, name_en, names, deleted_routes) values(?, ?, ?, ?, ?, ?, ?)");
+		updateStopStat = conn.prepareStatement("update transport_stop set names = ? where id = ?");
 		transRouteGeometryStat = conn.prepareStatement("insert into transport_route_geometry(route, geometry, ind) values(?, ?, ?)");
 		pStatements.put(transRouteStat, 0);
 		pStatements.put(transRouteStopsStat, 0);
 		pStatements.put(transStopsStat, 0);
+		pStatements.put(updateStopStat, 0);
 		pStatements.put(transRouteGeometryStat, 0);
 		
 		if(gtfsConnection != null) {
@@ -530,6 +538,8 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 					throw new IllegalArgumentException(e);
 				}
 				visitedStops.add(s.getId());
+			} else if (s.getNamesMap(false).containsKey(CONNECTED_STOP_IDS)) {
+				updatedPlatformStops.put(s.getId(), s);
 			}
 			transRouteStopsStat.setLong(1, r.getId());
 			transRouteStopsStat.setLong(2, s.getId());
@@ -538,12 +548,36 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 		}
 	}
 
+	private void updatePlatformStops() throws SQLException {
+		Gson gson = new Gson();
+		for (TransportStop stop : updatedPlatformStops.values()) {
+			updateStopStat.setString(1, gson.toJson(stop.getNamesMap(false)));
+			updateStopStat.setLong(2, stop.getId());
+			addBatch(updateStopStat);
+		}
+	}
 
+	private String getConnectedStopIds(EntityId platformId) {
+		Set<Long> stopIds = connectedStopIds.get(platformId);
+		if (stopIds == null || stopIds.isEmpty()) {
+			return null;
+		}
+		StringBuilder ids = new StringBuilder();
+		for (Long stopId : stopIds) {
+			if (ids.length() > 0) {
+				ids.append(',');
+			}
+			ids.append(stopId);
+		}
+		return ids.toString();
+	}
 
 	public void writeBinaryTransportIndex(BinaryMapIndexWriter writer, String regionName,
 			Connection mapConnection) throws IOException, SQLException {
 		try {
 			closePreparedStatements(transRouteStat, transRouteStopsStat, transStopsStat, transRouteGeometryStat);
+			updatePlatformStops();
+			closePreparedStatements(updateStopStat);
 			mapConnection.commit();
 			transportStopsTree.flush();
 
@@ -1100,7 +1134,7 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 			Entity e = entry.getEntity();
 			icc.translitJapaneseNames(e);
 			icc.translitChineseNames(e);
-			if (role.startsWith("platform")) {
+			if (role.startsWith("platform") || (role.isEmpty() && isPlatformEntity(e))) {
 				platformsAndStops.add(e);
 				platforms.add(e);
 			} else if (role.startsWith("stop")) {
@@ -1118,6 +1152,10 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 		}
 		for (Entity s : platformsAndStops) {
 			TransportStop stop = EntityParser.parseTransportStop(s);
+			String stopIds = getConnectedStopIds(EntityId.valueOf(s));
+			if (stopIds != null) {
+				stop.setName(CONNECTED_STOP_IDS, stopIds);
+			}
 			Relation stopArea = stopAreas.get(EntityId.valueOf(s));
 			// verify name tag, not stop.getName because it may contain unnecessary refs, etc
 			Entity genericStopName = null;
@@ -1134,6 +1172,11 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 		}
 
 		return true;
+	}
+
+	private boolean isPlatformEntity(Entity e) {
+		return "platform".equals(e.getTag(OSMTagKey.PUBLIC_TRANSPORT))
+				|| "platform".equals(e.getTag(OSMTagKey.RAILWAY));
 	}
 
 	private void mergePlatformsStops(List<Entity> platformsAndStopsToProcess, List<Entity> platforms, List<Entity> stops, 
@@ -1161,9 +1204,12 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 				}
 			}
 			if(replaceStop != null) {
-				platformsAndStopsToProcess.remove(platform);
-				if (!Algorithms.isEmpty(platform.getTag(OSMTagKey.NAME))) {
-					nameReplacement.put(EntityId.valueOf(replaceStop), platform);
+				platformsAndStopsToProcess.remove(replaceStop);
+				Set<Long> stopIds = connectedStopIds.computeIfAbsent(EntityId.valueOf(platform),
+						k -> new LinkedHashSet<Long>());
+				stopIds.add(EntityParser.parseTransportStop(replaceStop).getId());
+				if (!Algorithms.isEmpty(replaceStop.getTag(OSMTagKey.NAME))) {
+					nameReplacement.put(EntityId.valueOf(platform), replaceStop);
 				}
 			}
 		}


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/22830)

[related android request](https://github.com/osmandapp/OsmAnd/pull/25436)



### Transport Stop (Points)

---

40.53729 -3.89062
https://www.openstreetmap.org/node/7317152907 
(there are 6 routes but OsmAnd only displays 1) 

<img width="972" height="901" alt="Screenshot 2026-07-14 at 12 24 09" src="https://github.com/user-attachments/assets/ee30384e-255a-4b65-8b1f-4f3c973d97f3" />

---

40.51562 -3.89957
https://www.openstreetmap.org/node/2050786713 
(there are 7 routes but OsmAnd only displays 1)

<img width="965" height="911" alt="Screenshot 2026-07-14 at 12 25 58" src="https://github.com/user-attachments/assets/d2b77b2d-f7d1-4626-8036-a65879c96cfd" />

---

40.43444 -3.71925
https://www.openstreetmap.org/node/1439708980 
(there are 10 routes but OsmAnd displays 1 route from the nearest platform) 

<img width="969" height="905" alt="Screenshot 2026-07-14 at 12 26 20" src="https://github.com/user-attachments/assets/e5ccfd51-fc0d-4a4b-b40d-5a3bc3567e99" />

---


### Transport Platforms (Polygons)

40.73781 -4.06424
https://www.openstreetmap.org/way/190124171 
(there are 3 routes but OsmAnd displays 0)

<img width="962" height="903" alt="Screenshot 2026-07-14 at 12 26 38" src="https://github.com/user-attachments/assets/e546639d-5faf-4a86-ac44-80155effc447" />

---

40.70687 -4.06702
https://www.openstreetmap.org/way/1227180184 
(there is 1 route but OsmAnd displays 0, however the other platform of this train station is correct)

<img width="966" height="906" alt="Screenshot 2026-07-14 at 12 26 58" src="https://github.com/user-attachments/assets/15ccdc6c-fb27-414b-b60a-19345cee2ccd" />

---

40.47337 -3.68258
https://www.openstreetmap.org/way/202094336 
(user: there are 3 routes but OsmAnd displays 0)

<img width="1022" height="963" alt="Screenshot 2026-07-14 at 12 27 25" src="https://github.com/user-attachments/assets/24fb0290-0fd8-46d1-baea-f63e4177459a" />

---

### Navigation test

Start, end points:
40.4736526,-3.6823814    
40.40457 -3.68737

<img width="964" height="909" alt="Screenshot 2026-07-14 at 12 38 02" src="https://github.com/user-attachments/assets/fe0b8194-a639-4a45-828a-22937413b2fa" />

<img width="964" height="907" alt="Screenshot 2026-07-14 at 12 38 29" src="https://github.com/user-attachments/assets/e5ae3230-4f11-4c74-a6b1-e0dd1f619c97" />


---

### RandomRouteTester results 

left - before. right - after.
top - only selected route. bottom - all default routes:

selected test route: 
https://test.osmand.net/map/?start=40.4736526,-3.6823814&finish=40.0349402,-3.6186919&type=osmand&profile=public_transport#10/40.467307/-3.635057

<img width="1521" height="1081" alt="Screenshot 2026-07-14 at 12 30 43" src="https://github.com/user-attachments/assets/d7473d34-849e-4c94-ba0a-76fc2e8b131e" />

---

### obf files for testing:

[Madrid_crop_old.obf.zip](https://github.com/user-attachments/files/29340282/Madrid_crop_old.obf.zip)

[Madrid_crop_new2.obf.zip](https://github.com/user-attachments/files/29998206/Madrid_crop_new2.obf.zip)


