### PR TITLE
Pt-prioritize-platform-instead-of-stop-for-routes--9

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexTransportCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexTransportCreator.java
@@ -1100,9 +1100,13 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 			Entity e = entry.getEntity();
 			icc.translitJapaneseNames(e);
 			icc.translitChineseNames(e);
-			if (role.startsWith("platform")) {
-				platformsAndStops.add(e);
+			boolean isPlatform = role.startsWith("platform");
+			boolean isMergePlatformCandidate = role.isEmpty() && ("platform".equals(e.getTag(OSMTagKey.PUBLIC_TRANSPORT)) || "platform".equals(e.getTag(OSMTagKey.RAILWAY)));
+			if (isPlatform || isMergePlatformCandidate) {
 				platforms.add(e);
+				if (isPlatform) {
+					platformsAndStops.add(e);
+				}
 			} else if (role.startsWith("stop")) {
 				platformsAndStops.add(e);
 				stops.add(e);
@@ -1136,7 +1140,7 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 		return true;
 	}
 
-	private void mergePlatformsStops(List<Entity> platformsAndStopsToProcess, List<Entity> platforms, List<Entity> stops, 
+	private void mergePlatformsStops(List<Entity> platformsAndStopsToProcess, List<Entity> platforms, List<Entity> stops,
 			Map<EntityId, Entity> nameReplacement) {
 		// walk through platforms  and verify names from the second:
 		for(Entity platform : platforms) {
@@ -1161,14 +1165,20 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 				}
 			}
 			if(replaceStop != null) {
-				platformsAndStopsToProcess.remove(platform);
-				if (!Algorithms.isEmpty(platform.getTag(OSMTagKey.NAME))) {
-					nameReplacement.put(EntityId.valueOf(replaceStop), platform);
+				replaceStopWithPlatform(platformsAndStopsToProcess, platform, replaceStop);
+				if (!Algorithms.isEmpty(replaceStop.getTag(OSMTagKey.NAME))) {
+					nameReplacement.put(EntityId.valueOf(platform), replaceStop);
 				}
 			}
 		}
 	}
 
+	private void replaceStopWithPlatform(List<Entity> platformsAndStopsToProcess, Entity platform, Entity replaceStop) {
+		int stopInd = platformsAndStopsToProcess.indexOf(replaceStop);
+        if (stopInd >= 0) {
+            platformsAndStopsToProcess.set(stopInd, platform);
+		}
+	}
 
 	private boolean processTransportRelationV1(Relation rel, TransportRoute directRoute, TransportRoute backwardRoute) {
 		final Map<TransportStop, Integer> forwardStops = new LinkedHashMap<TransportStop, Integer>();

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexTransportCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexTransportCreator.java
@@ -1175,8 +1175,12 @@ public class IndexTransportCreator extends AbstractIndexPartCreator {
 
 	private void replaceStopWithPlatform(List<Entity> platformsAndStopsToProcess, Entity platform, Entity replaceStop) {
 		int stopInd = platformsAndStopsToProcess.indexOf(replaceStop);
+		int platformInd = platformsAndStopsToProcess.indexOf(platform);
         if (stopInd >= 0) {
             platformsAndStopsToProcess.set(stopInd, platform);
+			if (platformInd >= 0 && platformInd != stopInd) {
+				platformsAndStopsToProcess.remove(platformInd);
+			}
 		}
 	}
 


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/22830)

[connected android pr](https://github.com/osmandapp/OsmAnd/pull/25459)



### Transport Stop (Points)

---

40.53729 -3.89062
https://www.openstreetmap.org/node/7317152907 
(there are 6 routes but OsmAnd only displays 1) 

<img width="972" height="901" alt="Screenshot 2026-07-14 at 12 24 09" src="https://github.com/user-attachments/assets/ee30384e-255a-4b65-8b1f-4f3c973d97f3" />

---

40.51562 -3.89957
https://www.openstreetmap.org/node/2050786713 
(there are 7 routes but OsmAnd only displays 1)

<img width="965" height="911" alt="Screenshot 2026-07-14 at 12 25 58" src="https://github.com/user-attachments/assets/d2b77b2d-f7d1-4626-8036-a65879c96cfd" />

---

40.43444 -3.71925
https://www.openstreetmap.org/node/1439708980 
(there are 10 routes but OsmAnd displays 1 route from the nearest platform) 

<img width="969" height="905" alt="Screenshot 2026-07-14 at 12 26 20" src="https://github.com/user-attachments/assets/e5ccfd51-fc0d-4a4b-b40d-5a3bc3567e99" />

---


### Transport Platforms (Polygons)

40.73781 -4.06424
https://www.openstreetmap.org/way/190124171 
(there are 3 routes but OsmAnd displays 0)

<img width="962" height="903" alt="Screenshot 2026-07-14 at 12 26 38" src="https://github.com/user-attachments/assets/e546639d-5faf-4a86-ac44-80155effc447" />

---

40.70687 -4.06702
https://www.openstreetmap.org/way/1227180184 
(there is 1 route but OsmAnd displays 0, however the other platform of this train station is correct)

<img width="966" height="906" alt="Screenshot 2026-07-14 at 12 26 58" src="https://github.com/user-attachments/assets/15ccdc6c-fb27-414b-b60a-19345cee2ccd" />

---

40.47337 -3.68258
https://www.openstreetmap.org/way/202094336 
(user: there are 3 routes but OsmAnd displays 0)

<img width="1022" height="963" alt="Screenshot 2026-07-14 at 12 27 25" src="https://github.com/user-attachments/assets/24fb0290-0fd8-46d1-baea-f63e4177459a" />

---

### Navigation test

Start, end points:
40.4736526,-3.6823814    
40.40457 -3.68737

<img width="964" height="909" alt="Screenshot 2026-07-14 at 12 38 02" src="https://github.com/user-attachments/assets/fe0b8194-a639-4a45-828a-22937413b2fa" />

<img width="964" height="907" alt="Screenshot 2026-07-14 at 12 38 29" src="https://github.com/user-attachments/assets/e5ae3230-4f11-4c74-a6b1-e0dd1f619c97" />


---

### RandomRouteTester results 

left - before. right - after.
top - only selected route. bottom - all default routes:

selected test route: 
https://test.osmand.net/map/?start=40.4736526,-3.6823814&finish=40.0349402,-3.6186919&type=osmand&profile=public_transport#10/40.467307/-3.635057

<img width="1521" height="1081" alt="Screenshot 2026-07-14 at 12 30 43" src="https://github.com/user-attachments/assets/d7473d34-849e-4c94-ba0a-76fc2e8b131e" />

---

### obf files for testing:

[Madrid_crop_old.obf.zip](https://github.com/user-attachments/files/29340282/Madrid_crop_old.obf.zip)

[Madrid_crop_new36.obf.zip](https://github.com/user-attachments/files/30120841/Madrid_crop_new36.obf.zip)


