### PR TITLE
Avoid add to name index a low rating wiki objects

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexCreatorSettings.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexCreatorSettings.java
@@ -17,6 +17,8 @@ public class IndexCreatorSettings {
 
 	// use Sqlite in RAM instead of normal Sqlite (speeds up process but takes a lot of RAM)
 	public boolean processInRam;
+	
+	public boolean wikiQrankFilter = false;
 
 	// maximum tiles to use in RAM
 	public int maxHeightTilesInRam = -1;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
@@ -96,6 +96,8 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 	private int maxTagGroupId = 0;
 	private Map<Integer, PoiCreatorTagGroup> tagGroupsFromDB;
 
+    // avoid add to name index a low rating wiki objects
+    private static final int MIN_NAME_INDEX_QRANK = 1000;
 
 	// Actual list of brands is constantly regenerated from BrandAnalyzer utlitity
 	private static final String ENV_POI_TOP_INDEXES_URL = "POI_TOP_INDEXES_URL";
@@ -942,6 +944,7 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 		PoiAdditionalType streetRuleType = getOrCreate(Amenity.ADDR_STREET, null, true);
 		PoiAdditionalType hnoRuleType = getOrCreate(Amenity.ADDR_HOUSENUMBER, null, true);
 		PoiAdditionalType wikidataType = getOrCreate(Amenity.WIKIDATA, null, true);
+        PoiAdditionalType qrankType = getOrCreate(Amenity.QRANK, null, true);
 		Set<String> duplicateWikiWids = new HashSet<String>();
 
 		while (rs.next()) {
@@ -1125,7 +1128,14 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 						encoded.add(a);
 					}
 				}
- 				
+
+                if (additionalTags.get(qrankType) != null) {
+                    int qrank = Integer.parseInt(additionalTags.get(qrankType));
+                    if (qrank < MIN_NAME_INDEX_QRANK) {
+                        continue;
+                    }
+                }
+
 				PoiNameObject obj = new PoiNameObject(prevTree.getNode(), poiIndInBlock, elo, type, subtype,
 						encoded);
 				putPoiObjectPrefix(namesIndex, obj, additionalTags.get(nameRuleType),

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
@@ -97,7 +97,7 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 	private Map<Integer, PoiCreatorTagGroup> tagGroupsFromDB;
 
     // avoid add to name index a low rating wiki objects
-    private static final int MIN_NAME_INDEX_QRANK = 1000;
+    private static final int MIN_WIKI_QRANK = 1000;
 
 	// Actual list of brands is constantly regenerated from BrandAnalyzer utlitity
 	private static final String ENV_POI_TOP_INDEXES_URL = "POI_TOP_INDEXES_URL";
@@ -944,7 +944,7 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 		PoiAdditionalType streetRuleType = getOrCreate(Amenity.ADDR_STREET, null, true);
 		PoiAdditionalType hnoRuleType = getOrCreate(Amenity.ADDR_HOUSENUMBER, null, true);
 		PoiAdditionalType wikidataType = getOrCreate(Amenity.WIKIDATA, null, true);
-        PoiAdditionalType qrankType = getOrCreate("qrank", null, true);
+        PoiAdditionalType qrankType = settings.wikiQrankFilter ? getOrCreate("qrank", null, true) : null;
 		Set<String> duplicateWikiWids = new HashSet<String>();
 
 		while (rs.next()) {
@@ -1129,9 +1129,9 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 					}
 				}
 
-                if (additionalTags.get(qrankType) != null) {
+                if (settings.wikiQrankFilter && additionalTags.get(qrankType) != null) {
                     int qrank = Integer.parseInt(additionalTags.get(qrankType));
-                    if (qrank < MIN_NAME_INDEX_QRANK) {
+                    if (qrank < MIN_WIKI_QRANK) {
                         continue;
                     }
                 }

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexPoiCreator.java
@@ -944,7 +944,7 @@ public class IndexPoiCreator extends AbstractIndexPartCreator {
 		PoiAdditionalType streetRuleType = getOrCreate(Amenity.ADDR_STREET, null, true);
 		PoiAdditionalType hnoRuleType = getOrCreate(Amenity.ADDR_HOUSENUMBER, null, true);
 		PoiAdditionalType wikidataType = getOrCreate(Amenity.WIKIDATA, null, true);
-        PoiAdditionalType qrankType = getOrCreate(Amenity.QRANK, null, true);
+        PoiAdditionalType qrankType = getOrCreate("qrank", null, true);
 		Set<String> duplicateWikiWids = new HashSet<String>();
 
 		while (rs.next()) {

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/wiki/WikipediaByCountryDivider.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/wiki/WikipediaByCountryDivider.java
@@ -52,6 +52,7 @@ public class WikipediaByCountryDivider {
 		String[] testLatLon = null; 
 		public double testLat;
 		public double testLon;
+        public String country;
 	}
 
 	public static void main(String[] args) throws Exception {
@@ -71,7 +72,9 @@ public class WikipediaByCountryDivider {
 				in.database = val;
 			} else if (arg.startsWith("--ranking=")) {
 				in.wikiRankingDB = val;
-			}
+			} else if (arg.startsWith("--country=")) {
+                in.country = val.toLowerCase();
+            }
 		}
 
 		if (in.mode.isEmpty()) {
@@ -146,6 +149,9 @@ public class WikipediaByCountryDivider {
 			if(lcRegionName == null) {
 				continue;
 			}
+            if (args.country != null && !lcRegionName.startsWith(args.country)) {
+                continue;
+            }
 			String regionName = Algorithms.capitalizeFirstLetterAndLowercase(lcRegionName);
 			String preferredLang = preferredRegionLanguages.get(lcRegionName);
 			if(preferredLang == null) {

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/wiki/WikipediaByCountryDivider.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/wiki/WikipediaByCountryDivider.java
@@ -368,6 +368,7 @@ public class WikipediaByCountryDivider {
 		settings.indexTransport = false;
 		settings.indexRouting = false;
 		settings.poiZipLongStrings = true;
+		settings.wikiQrankFilter = true;
 		
 		IndexCreator creator = new IndexCreator(obf.getParentFile(), settings); //$NON-NLS-1$
 		new File(obf.getParentFile(), IndexCreator.TEMP_NODES_DB).delete();


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd/issues/25331
2. DEDUPICATE: too many houses (duplicate names) in wiki maps - obstruct search by street "Ярославів Вал"`?