### PR TITLE
Add authenticated empty-trash endpoint

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/StorageService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/StorageService.java
@@ -272,8 +272,13 @@ public class StorageService {
 					try {
 						st.s3Conn.deleteObject(st.bucket, fld + FILE_SEPARATOR + filename);
 					} catch (com.amazonaws.SdkClientException e) {
-						handleException(st, "delete", fld, filename, e);
-						throw e;
+						if (e instanceof AmazonS3Exception s3Exception
+								&& "NoSuchKey".equals(s3Exception.getErrorCode())) {
+							LOGGER.info(String.format("Storage delete skipped for missing file %s/%s", fld, filename));
+						} else {
+							handleException(st, "delete", fld, filename, e);
+							throw e;
+						}
 					}
 				}
 			}

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/UserdataService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/UserdataService.java
@@ -50,6 +50,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.google.common.cache.Cache;
@@ -109,6 +112,9 @@ public class UserdataService {
 
 	@Autowired
 	JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	PlatformTransactionManager transactionManager;
 
     @Autowired
     WebGpxParser webGpxParser;
@@ -798,28 +804,44 @@ public class UserdataService {
         return file != null;
     }
     
-    @Transactional
-    public ResponseEntity<String> emptyTrash(List<MapApiController.FileData> files, CloudUserDevicesRepository.CloudUserDevice dev) {
+    public ResponseEntity<String> emptyTrash(List<MapApiController.FileData> files,
+                                             CloudUserDevicesRepository.CloudUserDevice dev) {
         if (files == null) {
             return ResponseEntity.badRequest().body("Invalid trash file data");
         }
-        List<List<UserFile>> fileVersions = new ArrayList<>();
         for (MapApiController.FileData file : files) {
-            if (file == null || Algorithms.isEmpty(file.name) || Algorithms.isEmpty(file.type) || file.updatetime == null) {
+            if (file == null || Algorithms.isEmpty(file.name) || Algorithms.isEmpty(file.type)
+                    || file.updatetime == null) {
                 return ResponseEntity.badRequest().body("Invalid trash file data");
             }
-            List<UserFile> versions = filesRepository.findAllByUseridAndNameAndTypeOrderByUpdatetimeDesc(
-                    dev.userid, file.name, file.type);
-            String error = validateFileVersionsDeletion(versions, file.updatetime, true);
-            if (error != null) {
-                return ResponseEntity.badRequest().body(error);
+        }
+
+        EmptyTrashResponse response = new EmptyTrashResponse(files.size());
+        Map<TrashFileKey, TrashFileResult> processedFiles = new LinkedHashMap<>();
+        // Isolate every logical file so a stale item or a storage failure cannot roll back the whole batch.
+        TransactionTemplate transaction = deletionTransaction();
+        for (MapApiController.FileData file : files) {
+            TrashFileKey key = new TrashFileKey(file.name, file.type);
+            TrashFileResult previousResult = processedFiles.get(key);
+            TrashFileResult result;
+            if (previousResult != null) {
+                result = duplicateTrashFileResult(file, previousResult);
+            } else {
+                try {
+                    result = transaction.execute(status -> deleteTrashFile(dev.userid, file));
+                    if (result == null) {
+                        result = TrashFileResult.failed(file, "Could not delete file versions");
+                    }
+                } catch (RuntimeException e) {
+                    LOG.warn(String.format("Failed to empty Trash for user %d, file %s/%s: %s",
+                            dev.userid, file.type, file.name, e.getMessage()), e);
+                    result = TrashFileResult.failed(file, "Could not delete file versions");
+                }
+                processedFiles.put(key, result);
             }
-            fileVersions.add(versions);
+            response.addResult(result);
         }
-        for (List<UserFile> versions : fileVersions) {
-            deleteFileVersions(versions);
-        }
-        return ok();
+        return ResponseEntity.ok(gson.toJson(response));
     }
 
     private InputStream getGzipInputStreamFromFile(File fp, String ext) throws IOException {
@@ -936,36 +958,177 @@ public class UserdataService {
         return ok();
     }
     
-    @Transactional
-    public ResponseEntity<String> deleteFileAllVersions(int userid, String fileName, String fileType, Long updatetime, boolean isTrash) {
-        List<UserFile> files = filesRepository.findAllByUseridAndNameAndTypeOrderByUpdatetimeDesc(userid, fileName, fileType);
-        String error = validateFileVersionsDeletion(files, updatetime, isTrash);
-        if (error != null) {
-            return ResponseEntity.badRequest().body(error);
-        }
-        deleteFileVersions(files);
-        return ok();
-    }
+	public ResponseEntity<String> deleteFileAllVersions(int userid, String fileName, String fileType,
+	                                                    Long updatetime, boolean isTrash) {
+		String error = deletionTransaction().execute(status -> {
+			FileVersionsForDeletion versions = prepareVersionsForDeletion(userid, fileName, fileType);
+			String validationError = validateVersionsForDeletion(
+					versions.primaryVersions(), updatetime, isTrash, fileName, fileType);
+			if (validationError == null) {
+				deleteFileVersions(versions.allVersions());
+			}
+			return validationError;
+		});
+		return error == null ? ok() : ResponseEntity.badRequest().body(error);
+	}
 
-    private String validateFileVersionsDeletion(List<UserFile> files, Long updatetime, boolean isTrash) {
-        if (files.isEmpty()) {
-            return "File not found";
-        }
-        if (isTrash && files.get(0).zipfilesize > 0) {
-            return "This is not trash, the file is not deleted";
-        }
-        if (updatetime == null || files.get(0).updatetime.getTime() != updatetime) {
-            return "File version was changed";
-        }
-        return null;
-    }
+	private TrashFileResult deleteTrashFile(int userid, MapApiController.FileData file) {
+		FileVersionsForDeletion versions = prepareVersionsForDeletion(userid, file.name, file.type);
+		if (versions.primaryVersions().isEmpty()) {
+			return TrashFileResult.alreadyMissing(file, "File is already absent");
+		}
+		UserFile latestVersion = versions.primaryVersions().get(0);
+		if (!isDeletedVersion(latestVersion)) {
+			return TrashFileResult.skippedNotTrash(file, "The latest file version is not in Trash");
+		}
+		// A newer tombstone still expresses the same deletion intent, so a timestamp mismatch is not fatal here.
+		deleteFileVersions(versions.allVersions());
+		if (!Objects.equals(file.updatetime, latestVersion.updatetime == null
+				? null : latestVersion.updatetime.getTime())) {
+			return TrashFileResult.deleted(file,
+					"Deleted the current Trash version; the requested version had changed");
+		}
+		return TrashFileResult.deleted(file, null);
+	}
 
-    private void deleteFileVersions(List<UserFile> files) {
-        for (UserFile file : files) {
-            storageService.deleteFile(file.storage, userFolder(file), storageFileName(file));
-            filesRepository.delete(file);
-        }
-    }
+	private FileVersionsForDeletion prepareVersionsForDeletion(int userid, String fileName, String fileType) {
+		List<UserFile> primaryVersions = filesRepository.findAllByUseridAndNameAndTypeOrderByUpdatetimeDesc(
+				userid, fileName, fileType);
+		Map<Long, UserFile> allVersions = new LinkedHashMap<>();
+		for (UserFile file : primaryVersions) {
+			allVersions.put(file.id, file);
+		}
+		// GPX analysis is stored as a separate companion file and must not survive the source GPX.
+		if (FILE_TYPE_GPX.equals(fileType) && !fileName.endsWith(INFO_EXT)) {
+			List<UserFile> infoVersions = filesRepository.findAllByUseridAndNameAndTypeOrderByUpdatetimeDesc(
+					userid, fileName + INFO_EXT, fileType);
+			for (UserFile file : infoVersions) {
+				allVersions.put(file.id, file);
+			}
+		}
+		return new FileVersionsForDeletion(primaryVersions, new ArrayList<>(allVersions.values()));
+	}
+
+	private String validateVersionsForDeletion(List<UserFile> files, Long updatetime, boolean isTrash,
+	                                           String fileName, String fileType) {
+		String fileDescription = fileType + "/" + fileName;
+		if (files.isEmpty()) {
+			return "File not found: " + fileDescription;
+		}
+		UserFile latestVersion = files.get(0);
+		if (isTrash && !isDeletedVersion(latestVersion)) {
+			return "This is not trash, the file is not deleted: " + fileDescription;
+		}
+		if (updatetime == null || latestVersion.updatetime == null
+				|| latestVersion.updatetime.getTime() != updatetime) {
+			return "File version was changed: " + fileDescription;
+		}
+		return null;
+	}
+
+	private boolean isDeletedVersion(UserFile file) {
+		return file.zipfilesize != null && file.zipfilesize <= 0;
+	}
+
+	private void deleteFileVersions(List<UserFile> files) {
+		for (UserFile file : files) {
+			storageService.deleteFile(file.storage, userFolder(file), storageFileName(file));
+			filesRepository.delete(file);
+		}
+	}
+
+	private TransactionTemplate deletionTransaction() {
+		TransactionTemplate transaction = new TransactionTemplate(transactionManager);
+		transaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+		return transaction;
+	}
+
+	private TrashFileResult duplicateTrashFileResult(MapApiController.FileData file, TrashFileResult previousResult) {
+		return switch (previousResult.status) {
+			case TrashFileResult.DELETED, TrashFileResult.ALREADY_MISSING ->
+					TrashFileResult.alreadyMissing(file,
+							"Duplicate request item; no additional deletion was needed");
+			case TrashFileResult.SKIPPED_NOT_TRASH ->
+					TrashFileResult.skippedNotTrash(file,
+							"Duplicate request item; the latest file version is not in Trash");
+			default -> TrashFileResult.failed(file, "Duplicate request item; deletion failed");
+		};
+	}
+
+	private record TrashFileKey(String name, String type) {
+	}
+
+	private record FileVersionsForDeletion(List<UserFile> primaryVersions, List<UserFile> allVersions) {
+	}
+
+	private static class EmptyTrashResponse {
+		public final String status = "ok";
+		public final EmptyTrashSummary summary;
+		public final List<TrashFileResult> results = new ArrayList<>();
+
+		private EmptyTrashResponse(int requested) {
+			summary = new EmptyTrashSummary(requested);
+		}
+
+		private void addResult(TrashFileResult result) {
+			results.add(result);
+			switch (result.status) {
+				case TrashFileResult.DELETED -> summary.deleted++;
+				case TrashFileResult.ALREADY_MISSING -> summary.alreadyMissing++;
+				case TrashFileResult.SKIPPED_NOT_TRASH -> summary.skipped++;
+				default -> summary.failed++;
+			}
+		}
+	}
+
+	private static class EmptyTrashSummary {
+		public final int requested;
+		public int deleted;
+		public int alreadyMissing;
+		public int skipped;
+		public int failed;
+
+		private EmptyTrashSummary(int requested) {
+			this.requested = requested;
+		}
+	}
+
+	private static class TrashFileResult {
+		private static final String DELETED = "deleted";
+		private static final String ALREADY_MISSING = "already_missing";
+		private static final String SKIPPED_NOT_TRASH = "skipped_not_trash";
+		private static final String FAILED = "failed";
+
+		public final String name;
+		public final String type;
+		public final Long updatetime;
+		public final String status;
+		public final String message;
+
+		private TrashFileResult(MapApiController.FileData file, String status, String message) {
+			this.name = file.name;
+			this.type = file.type;
+			this.updatetime = file.updatetime;
+			this.status = status;
+			this.message = message;
+		}
+
+		private static TrashFileResult deleted(MapApiController.FileData file, String message) {
+			return new TrashFileResult(file, DELETED, message);
+		}
+
+		private static TrashFileResult alreadyMissing(MapApiController.FileData file, String message) {
+			return new TrashFileResult(file, ALREADY_MISSING, message);
+		}
+
+		private static TrashFileResult skippedNotTrash(MapApiController.FileData file, String message) {
+			return new TrashFileResult(file, SKIPPED_NOT_TRASH, message);
+		}
+
+		private static TrashFileResult failed(MapApiController.FileData file, String message) {
+			return new TrashFileResult(file, FAILED, message);
+		}
+	}
 
     @Transactional
     public ResponseEntity<String> renameFile(String oldName, String newName, String type, CloudUserDevicesRepository.CloudUserDevice dev, boolean saveCopy) throws IOException {

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/UserdataService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/UserdataService.java
@@ -800,8 +800,24 @@ public class UserdataService {
     
     @Transactional
     public ResponseEntity<String> emptyTrash(List<MapApiController.FileData> files, CloudUserDevicesRepository.CloudUserDevice dev) {
+        if (files == null) {
+            return ResponseEntity.badRequest().body("Invalid trash file data");
+        }
+        List<List<UserFile>> fileVersions = new ArrayList<>();
         for (MapApiController.FileData file : files) {
-            deleteFileAllVersions(dev.userid, file.name, file.type, file.updatetime, true);
+            if (file == null || Algorithms.isEmpty(file.name) || Algorithms.isEmpty(file.type) || file.updatetime == null) {
+                return ResponseEntity.badRequest().body("Invalid trash file data");
+            }
+            List<UserFile> versions = filesRepository.findAllByUseridAndNameAndTypeOrderByUpdatetimeDesc(
+                    dev.userid, file.name, file.type);
+            String error = validateFileVersionsDeletion(versions, file.updatetime, true);
+            if (error != null) {
+                return ResponseEntity.badRequest().body(error);
+            }
+            fileVersions.add(versions);
+        }
+        for (List<UserFile> versions : fileVersions) {
+            deleteFileVersions(versions);
         }
         return ok();
     }
@@ -923,20 +939,32 @@ public class UserdataService {
     @Transactional
     public ResponseEntity<String> deleteFileAllVersions(int userid, String fileName, String fileType, Long updatetime, boolean isTrash) {
         List<UserFile> files = filesRepository.findAllByUseridAndNameAndTypeOrderByUpdatetimeDesc(userid, fileName, fileType);
+        String error = validateFileVersionsDeletion(files, updatetime, isTrash);
+        if (error != null) {
+            return ResponseEntity.badRequest().body(error);
+        }
+        deleteFileVersions(files);
+        return ok();
+    }
+
+    private String validateFileVersionsDeletion(List<UserFile> files, Long updatetime, boolean isTrash) {
         if (files.isEmpty()) {
-            return ResponseEntity.badRequest().body("File not found");
+            return "File not found";
         }
         if (isTrash && files.get(0).zipfilesize > 0) {
-            return ResponseEntity.badRequest().body("This is not trash, the file is not deleted");
+            return "This is not trash, the file is not deleted";
         }
-        if (files.get(0).updatetime.getTime() != updatetime) {
-            return ResponseEntity.badRequest().body("File version was changed");
+        if (updatetime == null || files.get(0).updatetime.getTime() != updatetime) {
+            return "File version was changed";
         }
+        return null;
+    }
+
+    private void deleteFileVersions(List<UserFile> files) {
         for (UserFile file : files) {
             storageService.deleteFile(file.storage, userFolder(file), storageFileName(file));
             filesRepository.delete(file);
         }
-        return ok();
     }
 
     @Transactional

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/UserdataController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/UserdataController.java
@@ -343,6 +343,17 @@ public class UserdataController {
 		}
 	}
 
+	@PostMapping(value = "/empty-trash")
+	public ResponseEntity<String> emptyTrash(@RequestBody List<MapApiController.FileData> files,
+	                                        @RequestParam(name = "deviceid", required = true) int deviceId,
+	                                        @RequestParam(name = "accessToken", required = true) String accessToken) {
+		CloudUserDevice dev = checkToken(deviceId, accessToken);
+		if (dev == null) {
+			return userdataService.tokenNotValidError();
+		}
+		return userdataService.emptyTrash(files, dev);
+	}
+
 	@PostMapping(value = "/upload-file", consumes = MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<String> upload(@RequestPart(name = "file") @Valid @NotNull @NotEmpty MultipartFile file,
 			@RequestParam(name = "name", required = true) String name,


### PR DESCRIPTION
## Summary

- expose authenticated `POST /userdata/empty-trash` for mobile clients
- accept the existing `{name,type,updatetime}` batch payload
- validate the complete batch before deleting anything
- purge every historical version of each validated Trash item
- reuse the validation and deletion logic in `deleteFileAllVersions()`

## Context

Mobile clients previously deleted only the tombstone and one preceding version. Older versions could remain and reappear after synchronization.

Related to osmandapp/OsmAnd#24228.