### PR TITLE
(fix) Update OsmAndMapCreator.sh - missing JAVA_OPTS in runner script

### DIFF
--- a/java-tools/OsmAndMapCreator/src/main/resources/OsmAndMapCreator.sh
+++ b/java-tools/OsmAndMapCreator/src/main/resources/OsmAndMapCreator.sh
@@ -3,4 +3,4 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 if [ -z "$JAVA_OPTS" ]; then 
 	JAVA_OPTS="-Xms64M -Xmx1024M"
 fi
-java -Djava.util.logging.config.file="$DIR/logging.properties" -jar "$DIR/OsmAndMapCreator.jar"
+java -Djava.util.logging.config.file="$DIR/logging.properties" $JAVA_OPTS -jar "$DIR/OsmAndMapCreator.jar"


### PR DESCRIPTION
The script defined JAVA_OPTS but never passed it to the java invocation, causing the JVM to use default heap settings, ignoring the -Xmx setting. This led to OutOfMemoryError for large map compilations (java.lang.OutOfMemoryError: Java heap space). Added $JAVA_OPTS to the java command line.