### PR TITLE
Add the ocean rendered as land cases found by the world scan

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/resources/net/osmand/render/coastline-tests.json
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/resources/net/osmand/render/coastline-tests.json
@@ -8,7 +8,10 @@
     "reference raster tile. 'maps' are the obf files the case needs - they are downloaded from",
     "https://download.osmand.net/list into -maps.dir when they are missing.",
     "check: 'water' compares the water masks, 'seamarksInland' renders the maps of 'maps' alone",
-    "and requires the tile to stay empty."
+    "and requires the tile to stay empty.",
+    "The 'Ocean rendered as land' cases carry no 'maps': they are open ocean far from any detailed",
+    "map and are drawn from the basemap alone. They were found by -scan -minzoom=1 -maxzoom=5 over",
+    "the whole world, where the whole tile comes out as land while the reference is all water."
   ],
   "cases": [
     {
@@ -98,6 +101,66 @@
       "radius": 1,
       "check": "seamarksInland",
       "maps": ["World_seamarks_2.obf"]
+    },
+    {
+      "issue": 3291,
+      "title": "Ocean rendered as land: South Pacific",
+      "url": "https://github.com/osmandapp/OsmAnd-Issues/issues/3291",
+      "lat": -21.943,
+      "lon": -112.5,
+      "zooms": [3],
+      "radius": 0,
+      "maps": []
+    },
+    {
+      "issue": 3291,
+      "title": "Ocean rendered as land: Gulf of Alaska",
+      "url": "https://github.com/osmandapp/OsmAnd-Issues/issues/3291",
+      "lat": 52.483,
+      "lon": -140.625,
+      "zooms": [5],
+      "radius": 0,
+      "maps": []
+    },
+    {
+      "issue": 3291,
+      "title": "Ocean rendered as land: Pacific off Peru",
+      "url": "https://github.com/osmandapp/OsmAnd-Issues/issues/3291",
+      "lat": -16.636,
+      "lon": -84.375,
+      "zooms": [5],
+      "radius": 0,
+      "maps": []
+    },
+    {
+      "issue": 3291,
+      "title": "Ocean rendered as land: South Atlantic north",
+      "url": "https://github.com/osmandapp/OsmAnd-Issues/issues/3291",
+      "lat": -16.636,
+      "lon": 5.625,
+      "zooms": [5],
+      "radius": 0,
+      "maps": []
+    },
+    {
+      "issue": 3291,
+      "title": "Ocean rendered as land: South Atlantic south",
+      "url": "https://github.com/osmandapp/OsmAnd-Issues/issues/3291",
+      "lat": -27.059,
+      "lon": 5.625,
+      "zooms": [5],
+      "radius": 0,
+      "maps": []
+    },
+    {
+      "issue": 3291,
+      "title": "Ocean rendered as land: Amundsen Sea",
+      "url": "https://github.com/osmandapp/OsmAnd-Issues/issues/3291",
+      "lat": -72.396,
+      "lon": -140.625,
+      "zooms": [5],
+      "radius": 0,
+      "maps": []
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #1657. Turns the findings of the global scan into named cases in `coastline-tests.json`.

## What was found

`test-coastline-rendering -scan -minzoom=1 -maxzoom=5` over the whole world — 1364 tiles, 38 s — found six tiles of **open ocean that come out entirely as land** while the reference tile is all water. They are far from any detailed map, so they are drawn from the basemap alone and the cases carry no `maps`.

| tile | lat, lon | where | missing water |
|---|---|---|---|
| 3/1/4 | −21.943, −112.5 | South Pacific | 99.66% |
| 5/3/10 | 52.483, −140.625 | Gulf of Alaska | 100.00% |
| 5/8/17 | −16.636, −84.375 | Pacific off Peru | 97.38% |
| 5/16/17 | −16.636, 5.625 | South Atlantic | 100.00% |
| 5/16/18 | −27.059, 5.625 | South Atlantic | 100.00% |
| 5/3/25 | −72.396, −140.625 | Amundsen Sea | 100.00% |

Each was checked by eye: the rendered tile is the plain background colour, the reference is solid water. 3/1/4 is a z3 tile, so that is a very large piece of the South Pacific.

The same profile — `osmand ~0% water, reference 90–100%` — is what #24376, #25119 and #25618 also produce, which suggests **one common cause** (a missing ocean polygon) rather than separate bugs.

A seventh tile from the scan, 5/10/10 at 52.5/−61.9, is not added: its 2.12% is the St. Lawrence estuary of #25618 seen at z5, already covered by that case.

## Bali is deliberately not added

The two mangrove points from the comments of #24925 (`-8.73643, 115.18667` and `-8.77261, 115.18942`) do not reproduce with this method, so they would be misleading as cases:

- point A — 36 tiles at z13–16, worst 0.04% extra water, matches the reference;
- point B — one tile over the limit, 2.09% against a 2.00% threshold at z16, and the patch is a thin shoreline boundary difference in a built up area, not a flooded mangrove.

## Result

`utilities.sh test-coastline-rendering` is now 276 tiles, 38 failed, 14.5 s — the six new cases cost six tiles and about a second.

Only `coastline-tests.json` changes, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ewhEQGVv79BpPExDNXmxc