### PR TITLE
Write the report css into a file so Jenkins does not strip it

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
@@ -1115,8 +1115,10 @@ public class CoastlineRenderingTester {
 		StringBuilder sb = new StringBuilder();
 		sb.append("<!doctype html>\n<html lang=\"en\"><head><meta charset=\"utf-8\">\n");
 		sb.append("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\n");
-		sb.append("<title>OsmAnd coastline tiles</title>\n<style>\n").append(REPORT_CSS)
-				.append("</style></head><body>\n");
+		// Jenkins serves the workspace with "style-src 'self'", which forbids an inline <style>,
+		// so the css goes into a file next to index.html
+		sb.append("<title>OsmAnd coastline tiles</title>\n");
+		sb.append("<link rel=\"stylesheet\" href=\"" + REPORT_CSS_FILE + "\">\n</head><body>\n");
 		sb.append("<header><h1>Coastline rendering &mdash; epic 3291</h1>");
 		sb.append(String.format("<p class=\"sum\"><b class=\"%s\">%d failed</b> &middot; %d tiles compared "
 						+ "&middot; %d maps &middot; style %s &middot; %.1f s &middot; %s</p>",
@@ -1173,12 +1175,18 @@ public class CoastlineRenderingTester {
 			sb.append("</section>\n");
 		}
 		sb.append("</main>\n</body></html>\n");
+		File css = new File(outputDir, REPORT_CSS_FILE);
+		try (Writer wr = new OutputStreamWriter(new FileOutputStream(css), StandardCharsets.UTF_8)) {
+			wr.write(REPORT_CSS);
+		}
 		File report = new File(outputDir, "index.html");
 		try (Writer wr = new OutputStreamWriter(new FileOutputStream(report), StandardCharsets.UTF_8)) {
 			wr.write(sb.toString());
 		}
 		System.out.println("HTML report : " + report.getAbsolutePath());
 	}
+
+	private static final String REPORT_CSS_FILE = "styles.css";
 
 	private static final String REPORT_CSS =
 			":root{--bg:#fff;--fg:#1b1b1f;--mut:#6a6a75;--line:#e2e2e8;--card:#fafafc;"


### PR DESCRIPTION
The report opened from the Jenkins workspace renders as bare unstyled html.

## Cause

Jenkins serves workspace files with

```
Content-Security-Policy: sandbox; default-src 'none'; img-src 'self'; style-src 'self';
```

`style-src 'self'` permits a same-origin stylesheet **file** but not an inline `<style>` block — that would need `'unsafe-inline'`. The png tiles keep loading because of `img-src 'self'`, which is why the report looked half-broken rather than empty.

## Fix

The css goes into `styles.css` next to `index.html` and is pulled in with `<link rel="stylesheet" href="styles.css">`. No `<style>` block and no inline `style=` attributes are emitted any more, so the report renders the same from the workspace, from an archived artifact and from a local file. Nothing else changes.

Verified locally: `index.html` now starts with the `<link>`, `styles.css` is written next to it, and the page renders with the styling intact.