### PR TITLE
Read the obf indexes through indexes.cache in the working folder

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/NativeJavaRendering.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/NativeJavaRendering.java
@@ -538,8 +538,16 @@ public class NativeJavaRendering extends NativeLibrary {
 	}
 
 	public Map<String, FileIndex> initIndexesCache(File dir, List<File> filesToUse, boolean filterDuplicates) throws IOException {
+		return initIndexesCache(dir, new File(dir, INDEXES_CACHE), filesToUse, filterDuplicates);
+	}
+
+	/**
+	 * Same, but the cache is kept in {@code cacheFile} instead of the maps folder itself, for the
+	 * callers that must not write into a shared or read only maps folder.
+	 */
+	public Map<String, FileIndex> initIndexesCache(File dir, File cacheFile, List<File> filesToUse,
+			boolean filterDuplicates) throws IOException {
 		Map<String, FileIndex> map = new TreeMap<>();
-		File cacheFile = new File(dir, INDEXES_CACHE);
 		CachedOsmandIndexes cache = new CachedOsmandIndexes();
 		if (cacheFile.exists()) {
 			cache.readFromFile(cacheFile);
@@ -553,13 +561,20 @@ public class NativeJavaRendering extends NativeLibrary {
 			}
 			List<File> filteredMaps = mapsCollection.getFilesToUse();
 			for (File file : filteredMaps) {
-				FileIndex fileIndex = cache.getFileIndex(file, true);
+				FileIndex fileIndex;
+				try {
+					fileIndex = cache.getFileIndex(file, true);
+				} catch (IOException e) {
+					// a single broken obf must not abort the whole folder
+					log.error("Skipping map " + file.getAbsolutePath() + ": " + e.getMessage());
+					continue;
+				}
 				if (fileIndex != null) {
 					map.put(file.getAbsolutePath(), fileIndex);
+					if (filesToUse != null) {
+						filesToUse.add(file);
+					}
 				}
-			}
-			if (filesToUse != null) {
-				filesToUse.addAll(filteredMaps);
 			}
 		}
 		cache.writeToFile(cacheFile);

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
@@ -75,6 +75,9 @@ import net.osmand.util.MapUtils;
  * {@code case} initializes only the maps a case declares;</li>
  * <li>{@code basemap} - the basemap loaded in the {@code load=case} mode, default
  * {@code World_basemap_2.obf};</li>
+ * <li>{@code cache.dir} - folder holding {@code indexes.cache}, default the working folder; the
+ * cache is what keeps the native library from re-reading the index of every map on every run, and
+ * it is deliberately not written into the shared maps folder;</li>
  * <li>{@code exclude} - comma separated name parts that {@code load=all} skips, default
  * {@code World_seamarks,basemap_mini} - an overlay and a second basemap would distort the
  * rendering; pass {@code -exclude=} to load literally everything;</li>
@@ -137,6 +140,8 @@ public class CoastlineRenderingTester {
 
 	/** Without it the ocean is not rendered at all outside of the detailed maps. */
 	private static final String DEFAULT_BASEMAP = "World_basemap_2.obf";
+
+	private static final String INDEXES_CACHE = "indexes.cache";
 
 	// ----------------------------------------------------------------- json model
 
@@ -266,6 +271,7 @@ public class CoastlineRenderingTester {
 	private final File mapsDir;
 	private final File outputDir;
 	private final File referenceCacheDir;
+	private final File cacheDir;
 	private final boolean loadAllMaps;
 	private final boolean downloadMaps;
 	private final boolean cacheReference;
@@ -287,6 +293,8 @@ public class CoastlineRenderingTester {
 				.getAbsolutePath()));
 		this.outputDir = new File(opt("out", "build/coastline-tiles"));
 		this.referenceCacheDir = new File(opt("referenceDir", new File(outputDir, "reference").getPath()));
+		// the obf indexes cache lives in the working folder, never in the shared maps folder
+		this.cacheDir = new File(opt("cache.dir", System.getProperty("user.dir")));
 		this.loadAllMaps = !"case".equalsIgnoreCase(opt("load", "all"));
 		this.downloadMaps = Boolean.parseBoolean(opt("download", "true"));
 		this.cacheReference = Boolean.parseBoolean(opt("referenceCache", "true"));
@@ -458,17 +466,30 @@ public class CoastlineRenderingTester {
 		}
 	}
 
-	/** Initializes every map of the maps folder - the mode the server scan uses. */
-	private void initAllMaps() {
-		File[] ls = mapsDir.listFiles();
-		if (ls == null) {
+	/**
+	 * Initializes every map of the maps folder - the mode the server scan uses. The obf indexes are
+	 * read through {@code indexes.cache}, otherwise the native library reports "File not
+	 * initialized from cache" and re-reads the index of every single map on every run.
+	 */
+	private void initAllMaps() throws IOException {
+		if (!mapsDir.isDirectory()) {
 			System.err.println("Maps folder " + mapsDir.getAbsolutePath() + " does not exist");
 			return;
 		}
+		File cacheFile = new File(cacheDir, INDEXES_CACHE);
+		cacheFile.getParentFile().mkdirs();
+		boolean existed = cacheFile.isFile();
+		List<File> obfFiles = new ArrayList<>();
+		// picks the newest version of every region and writes/refreshes the cache
+		renderer.initIndexesCache(mapsDir, cacheFile, obfFiles, true);
+		renderer.initCacheMapFile(cacheFile.getAbsolutePath());
+		System.out.println("Indexes cache : " + cacheFile.getAbsolutePath()
+				+ (existed ? " (reused)" : " (created)"));
+
 		String[] excluded = opt("exclude", DEFAULT_EXCLUDED_MAPS).split(",");
 		List<File> maps = new ArrayList<>();
 		List<String> skipped = new ArrayList<>();
-		for (File f : ls) {
+		for (File f : obfFiles) {
 			String n = f.getName();
 			if (!f.isFile() || !n.endsWith(".obf") || n.endsWith(".road.obf") || n.endsWith(".srtm.obf")
 					|| n.endsWith(".srtmf.obf") || n.endsWith(".wiki.obf") || n.endsWith(".depth.obf")) {


### PR DESCRIPTION
Fixes the `WARN: Native File not initialized from cache: /home/tileserver/maps/....obf` flood in the build log.

## Cause

`initAllMaps` opened every map with a plain `initMapFile`, so the native library never got an index cache: it warned once per map and re-read the index of all of them on every run.

## Fix

The tester now builds `indexes.cache` and hands it to `initCacheMapFile` before opening the maps. The cache goes into the **working folder** — `-cache.dir`, default `user.dir`, so on Jenkins it lands in `$WORKSPACE` and survives between builds — and never into the maps folder, which on a tile server is shared and may be read only.

Measured with 126 maps locally:

| | init | warnings |
|---|---|---|
| cold, no cache | 11.6 s | 0 |
| second run, cache reused | **2.4 s** | 0 |

The gain grows with the number of maps; the builder loads 1078.

## Two supporting changes in NativeJavaRendering

- `initIndexesCache` got an overload that takes the cache file explicitly. The existing three argument method still writes into the maps folder, so no other caller changes behaviour.
- **A broken obf no longer aborts the whole folder.** `Uruguay_southamerica_2.obf` in a local maps folder is corrupt, and going through the index cache turned that into a fatal `IOException: Corrupt file, it should have ended as it starts with version` that killed the entire run before a single tile was rendered. It is now logged and skipped, and also kept out of the list of maps to open. Worth a look during review — it changes shared behaviour, but one bad file killing a 1078 map scan seems clearly wrong.

```
SEVERE: Skipping map .../Uruguay_southamerica_2.obf: Corrupt file, ...
Indexes cache : .../indexes.cache (created)
Initialized 126 maps from /Users/.../maps
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ewhEQGVv79BpPExDNXmxc