### PR TITLE
MapCreator: show HH alternative routes

### DIFF
--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
@@ -818,6 +818,7 @@ public class MapRouterLayer implements MapPanelLayer {
 						router.setHHRouteCpp(true);
 					}
 					HHRoutingConfig hhConfig = HHRoutePlanner.prepareDefaultRoutingConfig(null).cacheContext(cacheHHCtx);
+					hhConfig.calcAlternative(ALT_ROUTE_COLOURS.length);
 					router.setUseOnlyHHRouting(true).setHHRoutingConfig(hhConfig);
 					res = selfRoute(startRoute, endRoute, intermediates, false, previousRoute, router,  m);
 					if (USE_CACHE_CONTEXT) {
@@ -987,6 +988,80 @@ public class MapRouterLayer implements MapPanelLayer {
 	}
 
 
+	// "colour" is resolved as a java.awt.Color field name by MapPointsLayer.
+	// The main route is only coloured when alternatives are shown, otherwise it keeps the default black.
+	private static final String MAIN_ROUTE_COLOUR = "BLUE";
+	private static final String[] ALT_ROUTE_COLOURS = { "GREEN", "MAGENTA" };
+
+	private static double routeDistance(HHNetworkRouteRes route) {
+		double d = 0;
+		for (HHNetworkSegmentRes r : route.segments) {
+			if (r.list != null) {
+				for (RouteSegmentResult rs : r.list) {
+					int i = rs.getStartPointIndex(), end = rs.getEndPointIndex();
+					int step = i <= end ? 1 : -1;
+					while (i != end) {
+						d += MapUtils.getDistance(rs.getPoint(i), rs.getPoint(i + step));
+						i += step;
+					}
+				}
+			}
+		}
+		return d;
+	}
+
+	private static void addAlternativeRoutes(List<Entity> res, RouteCalcResult route) {
+		List<List<RouteSegmentResult>> alternatives = route.getAlternatives();
+		if (alternatives.isEmpty()) {
+			return;
+		}
+		double mainTime = 0, mainDist = 0;
+		for (RouteSegmentResult rs : route.getList()) {
+			mainTime += rs.getRoutingTime();
+			mainDist += rs.getDistance();
+		}
+		System.out.printf("Main route [%s] %.1f km, %.1f min%n",
+				MAIN_ROUTE_COLOUR.toLowerCase(), mainDist / 1000, mainTime / 60);
+		// last alternative first: entities are drawn in registration order, so the main route
+		// (added afterwards) always stays fully visible on top
+		for (int i = alternatives.size() - 1; i >= 0; i--) {
+			List<RouteSegmentResult> alt = alternatives.get(i);
+			String colour = ALT_ROUTE_COLOURS[i % ALT_ROUTE_COLOURS.length];
+			double dist = 0, time = 0;
+			for (RouteSegmentResult rs : alt) {
+				dist += rs.getDistance();
+				time += rs.getRoutingTime();
+			}
+			String label = String.format("alt %d: %.1f km, %.1f min (%+.1f%%)", i + 1,
+					dist / 1000, time / 60, mainTime > 0 ? 100 * (time / mainTime - 1) : 0);
+			System.out.println("Alternative route [" + colour.toLowerCase() + "] " + label);
+			// only the middle way carries the label - one caption per route instead of one per segment
+			int labelled = alt.size() / 2;
+			for (int k = 0; k < alt.size(); k++) {
+				res.add(altRouteWay(alt.get(k), colour, k == labelled ? label : null));
+			}
+		}
+	}
+
+	private static Way altRouteWay(RouteSegmentResult segment, String colour, String label) {
+		Way w = new Way(-1);
+		w.putTag("colour", colour);
+		if (label != null) {
+			w.putTag(OSMTagKey.NAME.getValue(), label);
+		}
+		int i = segment.getStartPointIndex(), end = segment.getEndPointIndex();
+		int step = i <= end ? 1 : -1;
+		while (true) {
+			LatLon l = segment.getPoint(i);
+			w.addNode(new net.osmand.osm.edit.Node(l.getLatitude(), l.getLongitude(), -1));
+			if (i == end) {
+				break;
+			}
+			i += step;
+		}
+		return w;
+	}
+
 	protected Collection<Entity> hhRoute(LatLon startRoute, LatLon endRoute) {
 		// specialize testing
 		try {
@@ -1010,7 +1085,9 @@ public class MapRouterLayer implements MapPanelLayer {
 //				hhPlanners.put(profile, hhRoutePlanner);
 //			}
 
-			HHNetworkRouteRes route = hhRoutePlanner.runRouting(startRoute, endRoute, null);
+			HHRoutingConfig hhConfig = HHRoutePlanner.prepareDefaultRoutingConfig(null);
+			hhConfig.calcAlternative(ALT_ROUTE_COLOURS.length);
+			HHNetworkRouteRes route = hhRoutePlanner.runRouting(startRoute, endRoute, hhConfig);
 			List<Entity> lst = new ArrayList<Entity>();
 			if (route.getError() != null) {
 				JOptionPane.showMessageDialog(OsmExtractionUI.MAIN_APP.getFrame(), route.getError(), "Routing error",
@@ -1018,7 +1095,7 @@ public class MapRouterLayer implements MapPanelLayer {
 				System.err.println(route.getError());
 			}
 			if (!route.getList().isEmpty()) {
-				calculateResult(lst, route.getList());
+				calculateResult(lst, route.getList(), route.altRoutes.isEmpty() ? null : MAIN_ROUTE_COLOUR);
 			} else {
 				TLongObjectHashMap<Entity> entities = new TLongObjectHashMap<Entity>();
 				for (HHNetworkSegmentRes r : route.segments) {
@@ -1032,19 +1109,30 @@ public class MapRouterLayer implements MapPanelLayer {
 				}
 				lst.addAll(entities.valueCollection());
 			}
-			for (HHNetworkRouteRes altRoute : route.altRoutes) {
-				TLongObjectHashMap<Entity> entities = new TLongObjectHashMap<Entity>();
+			double mainCost = route.getHHRoutingTime();
+			System.out.printf("HH route: %.1f km, %.1f min, %d alternative(s)\n",
+					routeDistance(route) / 1000, mainCost / 60, route.altRoutes.size());
+			List<Entity> altEntities = new ArrayList<Entity>();
+			for (int i = route.altRoutes.size() - 1; i >= 0; i--) {
+				HHNetworkRouteRes altRoute = route.altRoutes.get(i);
+				String colour = ALT_ROUTE_COLOURS[i % ALT_ROUTE_COLOURS.length];
+				double cost = altRoute.getHHRoutingTime();
+				double dist = routeDistance(altRoute);
+				String label = String.format("alt %d: %.1f km, %.1f min (%+.1f%%)", i + 1,
+						dist / 1000, cost / 60, 100 * (cost / mainCost - 1));
+				System.out.println("  " + colour.toLowerCase() + " - " + label);
+				List<RouteSegmentResult> segments = new ArrayList<RouteSegmentResult>();
 				for (HHNetworkSegmentRes r : altRoute.segments) {
 					if (r.list != null) {
-						for (RouteSegmentResult rs : r.list) {
-							HHRoutingUtilities.addWay(entities, rs, "highway", "tertiary");
-						}
-					} else if (r.segment != null) {
-						HHRoutingUtilities.addWay(entities, r.segment, "highway", "tertiary");
+						segments.addAll(r.list);
 					}
 				}
-				lst.addAll(entities.valueCollection());
+				int labelled = segments.size() / 2;
+				for (int k = 0; k < segments.size(); k++) {
+					altEntities.add(altRouteWay(segments.get(k), colour, k == labelled ? label : null));
+				}
 			}
+			lst.addAll(0, altEntities); // main route is registered last, so it stays on top
 
 			return lst;
 		} catch (Exception e) {
@@ -1116,7 +1204,9 @@ public class MapRouterLayer implements MapPanelLayer {
 						nextTurn.setText(">>");
 					}
 					this.previousRoute = searchRoute.getList();
-					calculateResult(res, searchRoute.getList());
+					boolean hasAlternatives = !searchRoute.getAlternatives().isEmpty();
+					addAlternativeRoutes(res, searchRoute);
+					calculateResult(res, searchRoute.getList(), hasAlternatives ? MAIN_ROUTE_COLOUR : null);
 				} finally {
 					if (ctx.calculationProgress != null) {
 						ctx.calculationProgress.isCancelled = true;
@@ -1251,6 +1341,10 @@ public class MapRouterLayer implements MapPanelLayer {
 	}
 
 	private void calculateResult(List<Entity> res, List<RouteSegmentResult> searchRoute) {
+		calculateResult(res, searchRoute, null);
+	}
+
+	private void calculateResult(List<Entity> res, List<RouteSegmentResult> searchRoute, String colour) {
 		RouteSegmentResult prevSegm = null;
 		int indVisual = 0;
 		for (RouteSegmentResult segm : searchRoute) {
@@ -1271,6 +1365,9 @@ public class MapRouterLayer implements MapPanelLayer {
 //			}
 //					String name = String.format("beg %.2f end %.2f ", s.getBearingBegin(), s.getBearingEnd());
 			way.putTag(OSMTagKey.NAME.getValue(), name);
+			if (colour != null) {
+				way.putTag("colour", colour);
+			}
 			if (prevSegm != null
 					&& MapUtils.getDistance(prevSegm.getEndPoint(), segm.getStartPoint()) > 0) {
 				net.osmand.osm.edit.Node pp = new net.osmand.osm.edit.Node(prevSegm.getEndPoint().getLatitude(), prevSegm.getEndPoint().getLongitude(), -1);


### PR DESCRIPTION
Draws the HH alternative routes in OsmAndMapCreator, so the plateau alternatives can be tested in OsmExtractionUI. Ref osmandapp/OsmAnd-Issues#2843.

Needs `RouteCalcResult.getAlternatives()` from the `hh-alt-routes-plateau` branch of the OsmAnd repo (osmandapp/OsmAnd#25805).

## What it changes

- **Alternatives are enabled on the path that the menu actually uses.** Worth flagging: the "HH route" action does *not* go through `MapRouterLayer.hhRoute()` — that call is commented out — it goes `calcRoute(mode, true)` → `selfRoute()` → `RoutePlannerFrontEnd.searchRoute`, so the alternatives had to be carried on `RouteCalcResult` to reach the map. `hhRoute()` (the HH-DB path) is updated the same way.
- **Colours.** Put on the ways as a `colour` tag, which `MapPointsLayer` resolves to a `java.awt.Color` field name: main route `BLUE`, alt 1 `GREEN`, alt 2 `MAGENTA`. The main route is only coloured when there is something to compare it with, so an ordinary (non-HH) route still renders exactly as before. `calculateResult` got a colour-aware overload; the old signature is kept.
- **Draw order.** Alternatives are registered before the main route and in reverse order (alt 2, alt 1, main), so the main route is drawn over them.
- **Labels.** A route is split into hundreds of `Way` entities and `MapPointsLayer` draws the `name` of every one of them, which buried the map under repeated captions. Now only one way per alternative — the middle one — carries the label, so there is a single caption per route.

The same summary goes to the console:

```
Main route [blue] 64.8 km, 60.5 min
Alternative route [green] alt 1: 64.7 km, 62.4 min (+3.1%)
Alternative route [magenta] alt 2: 64.7 km, 68.4 min (+13.1%)
```

## Known limitation

Entities are drawn in registration order *within a tile*: `DataTileManager.getObjects()` walks tiles by coordinate and keeps insertion order inside each one, and `registerObject` files a whole `Way` under a single tile by its centroid. So "main route on top" holds in practice but is not a global guarantee — where an alternative's ways and the main route's ways land in different tiles, a local overlap is still possible. A hard guarantee would need the routes drawn in a separate layer above `MapPointsLayer` rather than through the shared `DataTileManager`.

## Testing

Built with `./gradlew :OsmAndMapCreator:buildDistribution` and driven from OsmExtractionUI. Measured through the same `searchRoute` path the UI uses (`useOnlyHHRouting`, alternatives fully prepared with turns and distances):

| route | no alternatives | with 2 | found |
|---|---|---|---|
| Munich → Rosenheim | 835 ms | 948 ms | +1.4%, +15.7% |
| Berlin, urban | 489 ms | 640 ms | +6.4%, +6.3% |
| Lisbon → Porto (313 km) | 1537 ms | 1731 ms | +3.9%, +16.5% |

The server side moved to its own PR: osmandapp/OsmAnd-tools#1664.

---

## AI disclaimer

Written with Claude Code (Claude Opus 5), driven by @vshcherb. Summary of the requests it worked from, in order:

1. Analyse how to do alternative routes in OsmAnd; `HHRoutePlanner` is the main class; read the fast-routing blog post to see how HH works. What is wanted is *interesting, correct* alternatives — maximally different geometry at a similar time, not a detour around a pole for +5%. 1–2 alternatives always, and it has to be fast. The existing ideas are tied to opaque heuristics in the code; wanted an understandable one, roughly Google-like but not a black box, so it can be tuned on user feedback later. Run tests on the local maps, and decide what to compare against and which criteria to use.
2. Turn it into code, and draw the alternatives so they can be tested with HH.
3. Not the Android app — the thing to run is OsmExtractionUI (OsmAndMapCreator, tools project), `MapRouterLayer`.
4. Both routes have the same colour — give the second one a different colour. Which one is the optimal?
5. Too many labels on alt 1 / alt 2, they flood the map. Use green for alt 1 and magenta for alt 2. Reverse the draw order — alt 2 first, then alt 1, then the main route, so the main route is always fully visible on top.
6. Open pull requests from the tools and android branches.

All numbers in this description are measurements from those runs, not estimates.


