### PR TITLE
Server: return HH alternative routes from /routing/route

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
@@ -1098,11 +1098,39 @@ public class OsmAndMapsService {
 					hhConfig.ALT_MAX_COUNT = keepAlternatives;
 				}
 			}
+			if (alternatives > 0) {
+				String reason = alternativesUnsupportedBy(rp, ctx, router, intermediates);
+				if (reason != null) {
+					// they would silently come back empty otherwise, which reads as a broken feature
+					props.put("alternativesNotSupported", reason);
+				}
+			}
 		} finally {
 			unlockReaders(usedMapList);
 			unlockCacheRoutingContext(ctx);
 		}
 		return routeRes;
+	}
+
+	/**
+	 * Only the Java HH planner produces alternatives, and only for a plain start -> end route.
+	 * Returns what stands in the way, or null when alternatives can be expected.
+	 */
+	private String alternativesUnsupportedBy(RouteParameters rp, RoutingContext ctx,
+			RoutePlannerFrontEnd router, List<LatLon> intermediates) {
+		if (rp.onlineRouting != null) {
+			return "online routing";
+		}
+		if (ctx.nativeLib != null) {
+			return "native (C++) routing";
+		}
+		if (!router.isHHRoutingConfigured()) {
+			return "HH routing is off";
+		}
+		if (intermediates != null && !intermediates.isEmpty()) {
+			return "intermediate points";
+		}
+		return null;
 	}
 
 	private static long getLocalTimeMillisByLatLon(double lat, double lon) {

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
@@ -1024,6 +1024,17 @@ public class OsmAndMapsService {
 	public List<RouteSegmentResult> routing(boolean disableOldRouting, String routeMode, Map<String, Object> props,
 	                                        LatLon start, LatLon end, List<LatLon> intermediates, List<String> avoidRoadsIds,
 	                                        RouteCalculationProgress progress) throws IOException, InterruptedException {
+		return routing(disableOldRouting, routeMode, props, start, end, intermediates, avoidRoadsIds, progress, 0, null);
+	}
+
+	/**
+	 * @param alternatives how many alternative routes to ask HH routing for (0 - none)
+	 * @param alternativesOut filled with the alternatives that were found, may be null
+	 */
+	public List<RouteSegmentResult> routing(boolean disableOldRouting, String routeMode, Map<String, Object> props,
+	                                        LatLon start, LatLon end, List<LatLon> intermediates, List<String> avoidRoadsIds,
+	                                        RouteCalculationProgress progress, int alternatives,
+	                                        List<List<RouteSegmentResult>> alternativesOut) throws IOException, InterruptedException {
 		String profile = routeMode.split("\\,")[0];
 		QuadRect points = points(intermediates, start, end);
 		RoutePlannerFrontEnd router = new RoutePlannerFrontEnd();
@@ -1061,13 +1072,31 @@ public class OsmAndMapsService {
 			}
 			ctx.routingTime = 0;
 			ctx.calculationProgress = progress;
-			if (rp.onlineRouting != null) {
-				routeRes = onlineRouting(rp, ctx, router, props, start, end, intermediates);
-			} else {
-				RouteCalcResult rc = ctx.nativeLib != null ? runRoutingSync(start, end, intermediates, router, ctx)
-						: router.searchRoute(ctx, start, end, intermediates, null);
-				routeRes = rc == null ? null : rc.getList();
-				putResultProps(ctx, routeRes, props);
+			// the HH config can be shared with the routing cache, so the flag is set only for this
+			// request and put back before the context is unlocked
+			HHRoutingConfig hhConfig = alternatives > 0 ? router.getHHRoutingConfig() : null;
+			int keepAlternatives = hhConfig == null ? 0 : hhConfig.ALT_MAX_COUNT;
+			boolean keepCalcAlternatives = hhConfig != null && hhConfig.CALC_ALTERNATIVES;
+			if (hhConfig != null) {
+				hhConfig.calcAlternative(alternatives);
+			}
+			try {
+				if (rp.onlineRouting != null) {
+					routeRes = onlineRouting(rp, ctx, router, props, start, end, intermediates);
+				} else {
+					RouteCalcResult rc = ctx.nativeLib != null ? runRoutingSync(start, end, intermediates, router, ctx)
+							: router.searchRoute(ctx, start, end, intermediates, null);
+					routeRes = rc == null ? null : rc.getList();
+					if (rc != null && alternativesOut != null) {
+						alternativesOut.addAll(rc.getAlternatives());
+					}
+					putResultProps(ctx, routeRes, props);
+				}
+			} finally {
+				if (hhConfig != null) {
+					hhConfig.CALC_ALTERNATIVES = keepCalcAlternatives;
+					hhConfig.ALT_MAX_COUNT = keepAlternatives;
+				}
 			}
 		} finally {
 			unlockReaders(usedMapList);

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
@@ -212,9 +212,10 @@ public class RoutingService {
     }
 
     /**
-     * One LineString per alternative route, marked so that the client can draw and offer them
-     * differently from the main route. "alternative" is 1-based, "deltaTime" is the overhead
-     * against the main route in percent, measured the same way on both sides.
+     * One LineString per alternative route, with the same "overall" block as the main route so that
+     * a client can show an alternative in place of it. "alternative" is 1-based and marks the route
+     * as not the one currently displayed; "deltaTime" is the overhead against the main route,
+     * measured the same way on both sides.
      */
     public List<Feature> buildAlternativeFeatures(List<List<RouteSegmentResult>> alternatives,
                                                   List<RouteSegmentResult> mainRoute) {
@@ -225,30 +226,30 @@ public class RoutingService {
         double mainRoutingTime = routingTime(mainRoute);
         for (int i = 0; i < alternatives.size(); i++) {
             List<RouteSegmentResult> alt = alternatives.get(i);
-            List<LatLon> points = new ArrayList<>();
             double distance = 0, time = 0;
-            for (int k = 0; k < alt.size(); k++) {
-                RouteSegmentResult r = alt.get(k);
+            for (RouteSegmentResult r : alt) {
                 distance += r.getDistance();
                 time += r.getSegmentTime();
-                final int dir = r.isForwardDirection() ? 1 : -1;
-                // the very last segment has to include its very last point
-                final int last = k == alt.size() - 1 ? r.getEndPointIndex() + dir : r.getEndPointIndex();
-                for (int j = r.getStartPointIndex(); j != last; j += dir) {
-                    if (r.getPoint(j) != null) {
-                        points.add(r.getPoint(j));
-                    }
-                }
             }
+            // same elevation treatment as the main route, so the client can show its graph too
+            List<LatLonEle> points = getElevationsBySegments(new ArrayList<>(), new ArrayList<>(), alt);
+            interpolateEmptyElevationSegments(points);
             if (points.size() < 2) {
                 continue;
             }
-            Feature f = new Feature(Geometry.lineString(points));
+            Feature f = new Feature(Geometry.lineStringElevation(points));
             f.properties = new TreeMap<>();
             f.properties.put("alternative", i + 1);
-            f.properties.put("distance", distance);
-            f.properties.put("time", time);
-            f.properties.put("routingTime", routingTime(alt));
+            TreeMap<String, Object> overall = new TreeMap<>();
+            overall.put("distance", distance);
+            overall.put("time", time);
+            overall.put("routingTime", routingTime(alt));
+            f.properties.put("overall", overall);
+            List<Double> eleDiff = calculateElevationDiffs(points);
+            if (eleDiff.size() > 1 && !Double.isNaN(eleDiff.get(0)) && !Double.isNaN(eleDiff.get(1))) {
+                f.properties.put("diffElevationUp", eleDiff.get(0));
+                f.properties.put("diffElevationDown", eleDiff.get(1));
+            }
             if (mainRoutingTime > 0) {
                 double delta = 100 * (routingTime(alt) / mainRoutingTime - 1);
                 f.properties.put("deltaTime", Math.round(delta * 10) / 10.0);

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
@@ -212,34 +212,40 @@ public class RoutingService {
     }
 
     /**
-     * One LineString per alternative route, with the same "overall" block as the main route so that
-     * a client can show an alternative in place of it. "alternative" is 1-based and marks the route
-     * as not the one currently displayed; "deltaTime" is the overhead against the main route,
-     * measured the same way on both sides.
+     * Per alternative route: one LineString with the same "overall" block as the main route, so a
+     * client can show it in place of the main one, followed by that route's own turn descriptions.
+     * Everything belonging to an alternative carries the same 1-based "alternative" number - the
+     * client swaps the line and its turn points together, otherwise it would keep showing the
+     * directions of the route it just replaced.
+     *
+     * "overall.routingTime" is the sum of the segments' routing time, the same cost the main route
+     * reports (RoutingContext.routingTime accumulates it a segment at a time, so the two agree to
+     * within rounding).
      */
-    public List<Feature> buildAlternativeFeatures(List<List<RouteSegmentResult>> alternatives,
-                                                  List<RouteSegmentResult> mainRoute) {
+    public List<Feature> buildAlternativeFeatures(List<List<RouteSegmentResult>> alternatives) {
         List<Feature> features = new ArrayList<>();
-        if (alternatives == null || alternatives.isEmpty()) {
+        if (alternatives == null) {
             return features;
         }
-        double mainRoutingTime = routingTime(mainRoute);
-        for (int i = 0; i < alternatives.size(); i++) {
-            List<RouteSegmentResult> alt = alternatives.get(i);
+        int number = 0;
+        for (List<RouteSegmentResult> alt : alternatives) {
+            List<Feature> turns = new ArrayList<>();
+            // same elevation and turn treatment as the main route, so the client can show its graph
+            // and its directions too
+            List<LatLonEle> points = getElevationsBySegments(new ArrayList<>(), turns, alt);
+            interpolateEmptyElevationSegments(points);
+            if (points.size() < 2) {
+                continue; // numbering counts the alternatives that are returned, so it has no gaps
+            }
+            number++;
             double distance = 0, time = 0;
             for (RouteSegmentResult r : alt) {
                 distance += r.getDistance();
                 time += r.getSegmentTime();
             }
-            // same elevation treatment as the main route, so the client can show its graph too
-            List<LatLonEle> points = getElevationsBySegments(new ArrayList<>(), new ArrayList<>(), alt);
-            interpolateEmptyElevationSegments(points);
-            if (points.size() < 2) {
-                continue;
-            }
             Feature f = new Feature(Geometry.lineStringElevation(points));
             f.properties = new TreeMap<>();
-            f.properties.put("alternative", i + 1);
+            f.properties.put("alternative", number);
             TreeMap<String, Object> overall = new TreeMap<>();
             overall.put("distance", distance);
             overall.put("time", time);
@@ -250,11 +256,11 @@ public class RoutingService {
                 f.properties.put("diffElevationUp", eleDiff.get(0));
                 f.properties.put("diffElevationDown", eleDiff.get(1));
             }
-            if (mainRoutingTime > 0) {
-                double delta = 100 * (routingTime(alt) / mainRoutingTime - 1);
-                f.properties.put("deltaTime", Math.round(delta * 10) / 10.0);
-            }
             features.add(f);
+            for (Feature turn : turns) {
+                turn.prop("alternative", number);
+            }
+            features.addAll(turns);
         }
         return features;
     }

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
@@ -211,6 +211,63 @@ public class RoutingService {
         }
     }
 
+    /**
+     * One LineString per alternative route, marked so that the client can draw and offer them
+     * differently from the main route. "alternative" is 1-based, "deltaTime" is the overhead
+     * against the main route in percent, measured the same way on both sides.
+     */
+    public List<Feature> buildAlternativeFeatures(List<List<RouteSegmentResult>> alternatives,
+                                                  List<RouteSegmentResult> mainRoute) {
+        List<Feature> features = new ArrayList<>();
+        if (alternatives == null || alternatives.isEmpty()) {
+            return features;
+        }
+        double mainRoutingTime = routingTime(mainRoute);
+        for (int i = 0; i < alternatives.size(); i++) {
+            List<RouteSegmentResult> alt = alternatives.get(i);
+            List<LatLon> points = new ArrayList<>();
+            double distance = 0, time = 0;
+            for (int k = 0; k < alt.size(); k++) {
+                RouteSegmentResult r = alt.get(k);
+                distance += r.getDistance();
+                time += r.getSegmentTime();
+                final int dir = r.isForwardDirection() ? 1 : -1;
+                // the very last segment has to include its very last point
+                final int last = k == alt.size() - 1 ? r.getEndPointIndex() + dir : r.getEndPointIndex();
+                for (int j = r.getStartPointIndex(); j != last; j += dir) {
+                    if (r.getPoint(j) != null) {
+                        points.add(r.getPoint(j));
+                    }
+                }
+            }
+            if (points.size() < 2) {
+                continue;
+            }
+            Feature f = new Feature(Geometry.lineString(points));
+            f.properties = new TreeMap<>();
+            f.properties.put("alternative", i + 1);
+            f.properties.put("distance", distance);
+            f.properties.put("time", time);
+            f.properties.put("routingTime", routingTime(alt));
+            if (mainRoutingTime > 0) {
+                double delta = 100 * (routingTime(alt) / mainRoutingTime - 1);
+                f.properties.put("deltaTime", Math.round(delta * 10) / 10.0);
+            }
+            features.add(f);
+        }
+        return features;
+    }
+
+    private static double routingTime(List<RouteSegmentResult> route) {
+        double t = 0;
+        if (route != null) {
+            for (RouteSegmentResult r : route) {
+                t += r.getRoutingTime();
+            }
+        }
+        return t;
+    }
+
     public List<LatLonEle> getElevationsBySegments(List<LatLonEle> resListEle,
                                             List<Feature> features, List<RouteSegmentResult> res) {
         for (int i = 0; i < res.size(); i++) {

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/RoutingController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/RoutingController.java
@@ -290,7 +290,8 @@ public class RoutingController {
 	public ResponseEntity<String> routing(HttpSession session,
 			@RequestParam String[] points, @RequestParam(defaultValue = "car") String routeMode,
 	                                 @RequestParam(required = false) String[] avoidRoads,
-	                                 @RequestParam(defaultValue = "production") String limits) throws IOException {
+	                                 @RequestParam(defaultValue = "production") String limits,
+	                                 @RequestParam(defaultValue = "0") int alternatives) throws IOException {
 		RouteCalculationProgress progress = this.session.getRoutingProgress(session);
 		final int hhOnlyLimit = osmAndMapsService.getRoutingConfig().hhOnlyLimit;
 		List<LatLon> list = new ArrayList<>();
@@ -316,13 +317,17 @@ public class RoutingController {
 		}
 		List<LatLonEle> resListElevation = new ArrayList<>();
 		List<Feature> features = new ArrayList<>();
+		List<Feature> alternativeFeatures = new ArrayList<>();
 		Map<String, Object> props = new TreeMap<>();
 		if (list.size() >= 2) {
 			try {
+				List<List<RouteSegmentResult>> altRoutes = new ArrayList<>();
 				List<RouteSegmentResult> res =
 						osmAndMapsService.routing(disableOldRouting, routeMode, props, list.get(0),
 								list.get(list.size() - 1), list.subList(1, list.size() - 1),
-								avoidRoads == null ? Collections.emptyList() : Arrays.asList(avoidRoads), progress);
+								avoidRoads == null ? Collections.emptyList() : Arrays.asList(avoidRoads), progress,
+								alternatives, altRoutes);
+				alternativeFeatures = routingService.buildAlternativeFeatures(altRoutes, res);
 				if (res != null) {
 					resListElevation = routingService.getElevationsBySegments(resListElevation, features, res);
 					routingService.interpolateEmptyElevationSegments(resListElevation);
@@ -355,6 +360,8 @@ public class RoutingController {
 				new Feature(Geometry.lineStringElevation(resListElevation));
 		route.properties = props;
 		features.add(0, route);
+		// alternatives go last so that the main route stays the first feature
+		features.addAll(alternativeFeatures);
 
 		if (reportLimitError && dist >= hhOnlyLimit * 1000) {
 			return ResponseEntity.ok(gson.toJson(Map.of("features", new FeatureCollection(features.toArray(new Feature[features.size()])), "msg",

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/RoutingController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/RoutingController.java
@@ -58,6 +58,8 @@ import net.osmand.util.MapUtils;
 @RequestMapping("/routing")
 public class RoutingController {
 	public static final String MSG_LONG_DIST = "Sorry, in our beta mode max routing distance is limited to ";
+	/** each alternative costs a detailed expansion, and no client asks for more than a couple */
+	private static final int MAX_ALTERNATIVES = 2;
 	protected static final Log LOGGER = LogFactory.getLog(RoutingController.class);
 
 	@Autowired
@@ -292,6 +294,8 @@ public class RoutingController {
 	                                 @RequestParam(required = false) String[] avoidRoads,
 	                                 @RequestParam(defaultValue = "production") String limits,
 	                                 @RequestParam(defaultValue = "0") int alternatives) throws IOException {
+		// client controlled, and every alternative costs a detailed expansion on the server
+		final int altCount = Math.min(Math.max(alternatives, 0), MAX_ALTERNATIVES);
 		RouteCalculationProgress progress = this.session.getRoutingProgress(session);
 		final int hhOnlyLimit = osmAndMapsService.getRoutingConfig().hhOnlyLimit;
 		List<LatLon> list = new ArrayList<>();
@@ -326,8 +330,8 @@ public class RoutingController {
 						osmAndMapsService.routing(disableOldRouting, routeMode, props, list.get(0),
 								list.get(list.size() - 1), list.subList(1, list.size() - 1),
 								avoidRoads == null ? Collections.emptyList() : Arrays.asList(avoidRoads), progress,
-								alternatives, altRoutes);
-				alternativeFeatures = routingService.buildAlternativeFeatures(altRoutes, res);
+								altCount, altRoutes);
+				alternativeFeatures = routingService.buildAlternativeFeatures(altRoutes);
 				if (res != null) {
 					resListElevation = routingService.getElevationsBySegments(resListElevation, features, res);
 					routingService.interpolateEmptyElevationSegments(resListElevation);


### PR DESCRIPTION
Returns the alternative routes that HH routing finds from `/routing/route`, so the map can draw them. Needs osmandapp/OsmAnd#25805 for the router itself. Ref osmandapp/OsmAnd-Issues#2855.

## API

New request parameter `alternatives`, 0 by default — nothing changes for callers that do not ask. When set, HH routing is asked for that many alternatives and each one is appended to the FeatureCollection as its own LineString after the main route:

| property | meaning |
|---|---|
| `alternative` | 1-based index; marks the route as not the one being shown |
| `overall.distance` / `overall.time` / `overall.routingTime` | the same block the main route carries |
| `diffElevationUp` / `diffElevationDown` | as for the main route |
| `deltaTime` | overhead against the main route, percent |

Alternatives get their elevation from the same `getElevationsBySegments()` the main route goes through, and the same `overall` shape, so a client can put an alternative in place of the route it is showing and have the summary and the elevation graph keep working. That is what osmandapp/web#1975 does on click.

The HH config can be shared with the routing cache, so `CALC_ALTERNATIVES` is set for the request only and put back before the context is unlocked.

## Testing

Local server over `Ukraine_kyiv_europe_2.obf`, Podil → Teremky (`50.46904,30.51638` → `50.37401,30.44741`): two alternatives, 16.2 km (+0.5%) and 27.5 km (+9.4%). Checked both directly and through the map's dev proxy.

Worth knowing when comparing against the unit tests: this pair has two nearly tied optima — 25.5 km at 42 km/h round the west and 16.2 km at 23 km/h through the centre, 1881 against 1877 of cost. Which one comes back as the main route depends on the search order, and the other one is offered as an alternative at +0.5%. Nothing is wrong when they swap places between two setups.

---

## AI disclaimer

Written with Claude Code (Claude Opus 5), driven by @vshcherb. Summary of the requests it worked from, in order:

1. Analyse how to do alternative routes in OsmAnd; `HHRoutePlanner` is the main class; read the fast-routing blog post to see how HH works. What is wanted is *interesting, correct* alternatives — maximally different geometry at a similar time, not a detour around a pole for +5%. 1–2 alternatives always, and it has to be fast. The existing ideas are tied to opaque heuristics in the code; wanted an understandable one, roughly Google-like but not a black box, so it can be tuned on user feedback later. Run tests on the local maps, and decide what to compare against and which criteria to use.
2. Turn it into code, and draw the alternatives so they can be tested with HH.
3. Not the Android app — the thing to run is OsmExtractionUI (OsmAndMapCreator, tools project), `MapRouterLayer`.
4. Both routes have the same colour — give the second one a different colour. Which one is the optimal?
5. Too many labels on alt 1 / alt 2, they flood the map. Use green for alt 1 and magenta for alt 2. Reverse the draw order — alt 2 first, then alt 1, then the main route, so the main route is always fully visible on top.
6. Open pull requests from the tools and android branches.

All numbers in this description are measurements from those runs, not estimates.
