### PR TITLE
Encode osmand_region_ref with ref:USPS / ISO3166-2 (LLM)

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/util/CountryOcbfGeneration.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/util/CountryOcbfGeneration.java
@@ -26,6 +26,7 @@ import java.util.TreeMap;
 import net.osmand.PlatformUtil;
 import net.osmand.binary.MapZooms;
 import net.osmand.impl.ConsoleProgressImplementation;
+import net.osmand.map.OsmandRegions;
 import net.osmand.obf.preparation.IndexCreator;
 import net.osmand.obf.preparation.IndexCreatorSettings;
 import net.osmand.osm.MapRenderingTypesEncoder;
@@ -37,6 +38,9 @@ import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlSerializer;
 
 public class CountryOcbfGeneration {
+	private static final String TAG_REF_USPS = "ref:USPS"; // US state abbreviation
+	private static final String TAG_ISO_3166_2 = "ISO3166-2"; // ISO subdivision code
+
 	private int OSM_ID=-1000;
 	private static final Log log = PlatformUtil.getLog(CountryOcbfGeneration.class);
 
@@ -409,6 +413,7 @@ public class CountryOcbfGeneration {
         encoder.addExternalAdditionalText("short_name", true);
         encoder.addExternalAdditionalText("alt_name", true);
         encoder.addExternalAdditionalText("name:abbreviation", false);
+        encoder.addExternalAdditionalText(OsmandRegions.FIELD_REGION_REF, false);
         creator.generateIndexes(osm,
 				new ConsoleProgressImplementation(1), null, zooms,
 				encoder, log);
@@ -561,6 +566,11 @@ public class CountryOcbfGeneration {
 			} else {
 				TranslateEntity nt = set.iterator().next();
 				line += " translate-" + nt.tm.size() + "=" + nt.tm.get("name");
+				String uspsRef = nt.tm.get(TAG_REF_USPS);
+				String regionRef = Algorithms.isNotEmpty(uspsRef) ? uspsRef : nt.tm.get(TAG_ISO_3166_2);
+				if (Algorithms.isNotEmpty(regionRef)) {
+					addTag(serializer, OsmandRegions.FIELD_REGION_REF, regionRef);
+				}
 				Iterator<Entry<String, String>> it = nt.tm.entrySet().iterator();
                 boolean hasBoundary = false;
 				while (it.hasNext()) {


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd/issues/25485

## AI disclaimer

Produced with Codex (GPT-5), including the added and revised tests.

Prompts used (summarised):

1. Investigate issue #25485 and identify the first bug involving region references and regions.ocbf.
2. Analyse OCBF contents and generation for FR-55, numeric 55, and Pennsylvania PA.
3. Generate osmand_region_ref from ref:USPS, falling back to ISO3166-2, while preserving the original ref.
4. Update the client, constants, tests, and region matching to use the new field; remove the one-character bypass.
5. Generate a fresh local OCBF, inspect its dump, and run the relevant tests, excluding OsmandRegionsTest until explicitly requested.
6. Refine matching so PA remains available to address search while 55 does not match FR-55; use a separate regionSearchRef and exact ref comparison.
7. Update the existing OsmandRegionsTest and restore shared matcher reuse.

Decided by the agent, not requested explicitly: registered osmand_region_ref as a non-localized OCBF text field, added regionSearchRef to WorldRegion, and used a temporary local OCBF generation and test workflow for validation.