### PR TITLE
Recognize Polish Wikivoyage listing templates (zobacz/znacznik)

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/wiki/PoiFieldCategory.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/wiki/PoiFieldCategory.java
@@ -1,13 +1,13 @@
 package net.osmand.wiki;
 
 public enum PoiFieldCategory {
-	SEE("special_photo_camera", 0xCC10A37E, new String[] { "see", "voir", "veja", "מוקדי", "دیدن" }, "church", "mosque",
+	SEE("special_photo_camera", 0xCC10A37E, new String[] { "see", "voir", "veja", "מוקדי", "دیدن", "zobacz" }, "church", "mosque",
 			"square", "town_hall", "building", "veja", "voir", "temple", "mosque", "synagogue", "monastery", "palace",
 			"château", "memorial", "archaeological", "fort", "monument", "castle", "دیدن", "tower", "cathedral",
-			"arts centre", "mill", "house", "ruins"),
+			"arts centre", "mill", "house", "ruins", "zabytek", "atrakcja"),
 	DO("special_photo_camera", 0xCC10A37E, new String[] { "do", "event", "פעילויות", "انجام‌دادن" }, "museum", "zoo",
 			"theater", "fair", "faire", "cinema", "disco", "sauna", "aquarium", "swimming", "amusement", "golf", "club",
-			"sports", "music", "spa", "انجام‌دادن", "festival"),
+			"sports", "music", "spa", "انجام‌دادن", "festival", "muzeum"),
 	EAT("restaurants", 0xCCCA2D1D, new String[] { "eat", "manger", "coma", "אוכל", "خوردن" }, "restaurant", "cafe",
 			"bistro"),
 	DRINK("restaurants", 0xCCCA2D1D, new String[] { "drink", "boire", "beba", "שתייה", "نوشیدن" }, "bar", "pub"),
@@ -16,8 +16,8 @@ public enum PoiFieldCategory {
 	BUY("shop_department_store", 0xCC8F2BAB, new String[] { "buy", "קניות", "فهرست‌بندی" }, "shop", "market", "mall"),
 	GO("public_transport_stop_position", 0xCC0F5FFF,
 			new String[] { "go", "destination", "aller", "circuler", "sortir", "רשימה" }, "airport", "train", "station",
-			"bus"),
-	NATURAL("special_photo_camera", 0xCC10A37E, new String[] { "landscape", "island", "nature", "island" }, "park",
+			"bus", "transport"),
+	NATURAL("special_photo_camera", 0xCC10A37E, new String[] { "landscape", "island", "nature", "island", "natura" }, "park",
 			"cemetery", "garden", "lake", "beach", "landmark", "cemetery", "cave", "garden", "waterfall", "viewpoint",
 			"mountain"),
 	OTHER("", 0xCC0F5FFF, new String[] { "other", "marker", "ville", "item", "רשימה", "دیدن", "יעד מרכזי",

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/wiki/WikiDatabasePreparation.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/wiki/WikiDatabasePreparation.java
@@ -974,13 +974,13 @@ public class WikiDatabasePreparation {
 
 	private static PoiFieldCategory transformCategory(String[] info) {
 		// {{listing | type=go}
-		// en: type, pt: tipo, fr: group,
+		// en: type, pt: tipo, fr: group, pl: typ
 		PoiFieldCategory res = PoiFieldCategory.OTHER;
 		for (int i = 0; i < info.length; i++) {
 			int ind = info[i].indexOf('=');
 			if (ind >= 0) {
 				String key = info[i].substring(0, ind).trim();
-				if (key.equals("type") || key.equals("tipo") || key.equals("group")) {
+				if (key.equals("type") || key.equals("tipo") || key.equals("group") || key.equals("typ")) {
 					String val = info[i].substring(ind + 1).toLowerCase().trim();
 					for (PoiFieldCategory p : PoiFieldCategory.values()) {
 						for (String s : p.names) {
@@ -1008,7 +1008,8 @@ public class WikiDatabasePreparation {
 	}
 
 	private static PoiFieldCategory isPOIKey(String str, String lang) {
-		if (str.startsWith("listing") || str.startsWith("vcard")) {
+		// pl: {{znacznik | typ=...}} is the generic listing template (like en "listing")
+		if (str.startsWith("listing") || str.startsWith("vcard") || str.startsWith("znacznik")) {
 			return transformCategory(str.split("\\|"));
 		}
 		for (PoiFieldCategory p : PoiFieldCategory.values()) {


### PR DESCRIPTION
## Summary
- Polish Wikivoyage uses `{{zobacz}}` for sightseeing listings and the generic `{{znacznik|typ=...}}` template for other POI categories, instead of `{{listing}}`/`{{vcard}}` with `type=`/`tipo=`/`group=`.
- `isPOIKey()`/`transformCategory()` in `WikiDatabasePreparation.java` didn't recognize these, so the whole template block was silently dropped while converting wikitext to HTML — leaving sections like "Warto zobaczyć" (See) empty for Polish travel articles.
- Added `zobacz`/`znacznik`/`typ=` recognition plus a few Polish `typ` values (`transport`, `natura`, `zabytek`, `atrakcja`, `muzeum`) to `PoiFieldCategory.java`.

Verified against the raw wikitext of `pl.wikivoyage.org/wiki/Wilno` and the `Szablon:Znacznik` template doc.

Fixes https://github.com/osmandapp/OsmAnd/issues/25600

## Test plan
- [x] `./gradlew --offline :OsmAndMapCreatorUtilities:compileJava` succeeds
- [ ] Regenerate the Polish travel OBF and confirm the "Warto zobaczyć" section for Vilnius now shows POIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)