### PR TITLE
Server: look up Apple order id from the customer's receipt email

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/AppleOrderLookupService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/AppleOrderLookupService.java
@@ -1,0 +1,117 @@
+package net.osmand.server.api.services;
+
+import net.osmand.purchases.AppStoreOrderLookupHelper;
+import net.osmand.purchases.AppStoreOrderLookupHelper.AppStoreTransaction;
+import net.osmand.purchases.AppStoreOrderLookupHelper.OrderLookupResult;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Resolves an Apple order id (the id from the receipt email Apple sends to the customer, MXXXXXXXXX)
+ * into the purchases we store. Apple purchases are keyed in supporters_device_sub /
+ * supporters_device_iap by original_transaction_id, which the customer never sees, so without this
+ * lookup an order id from the email cannot be found in order management at all.
+ */
+@Service
+public class AppleOrderLookupService {
+
+	protected static final Log LOG = LogFactory.getLog(AppleOrderLookupService.class);
+
+	private static final int PURCHASES_PER_TRANSACTION = 10;
+
+	private final AppStoreOrderLookupHelper lookupHelper = new AppStoreOrderLookupHelper();
+
+	@Autowired
+	private OrderManagementService orderManagementService;
+
+	public static class AppleOrderLookup {
+		public String orderId;
+		public boolean configured = true;
+		public boolean found;
+		public String error;
+		public List<AppleTransaction> transactions = new ArrayList<>();
+		// rows of supporters_device_sub / supporters_device_iap behind the transactions above
+		public List<AdminService.Purchase> purchases = new ArrayList<>();
+	}
+
+	public static class AppleTransaction {
+		// original_transaction_id, stored as orderid for Apple purchases
+		public String orderId;
+		public String transactionId;
+		public String sku;
+		public String type;
+		public String environment;
+		public String storefront;
+		public Date purchaseTime;
+		public Date expireTime;
+		public Date revocationTime;
+		// whether we have a row with this orderid
+		public boolean stored;
+	}
+
+	public boolean isConfigured() {
+		return lookupHelper.isConfigured();
+	}
+
+	public AppleOrderLookup lookup(String orderId) {
+		AppleOrderLookup res = new AppleOrderLookup();
+		res.orderId = orderId;
+		if (!isConfigured()) {
+			res.configured = false;
+			res.error = "App Store Server API key is not configured on the server";
+			return res;
+		}
+		OrderLookupResult lookupResult;
+		try {
+			lookupResult = lookupHelper.lookupOrder(orderId);
+		} catch (IOException | RuntimeException e) {
+			LOG.error("Apple order lookup failed for " + orderId + ": " + e.getMessage(), e);
+			res.error = "Apple order lookup failed: " + e.getMessage();
+			return res;
+		}
+		if (!lookupResult.isValidOrder()) {
+			res.error = "Apple does not know order id " + orderId;
+			return res;
+		}
+		res.found = true;
+		Set<String> processedOrderIds = new LinkedHashSet<>();
+		for (AppStoreTransaction t : lookupResult.transactions) {
+			AppleTransaction transaction = new AppleTransaction();
+			transaction.orderId = t.originalTransactionId;
+			transaction.transactionId = t.transactionId;
+			transaction.sku = t.productId;
+			transaction.type = t.type;
+			transaction.environment = t.environment;
+			transaction.storefront = t.storefront;
+			transaction.purchaseTime = toDate(t.purchaseDate);
+			transaction.expireTime = toDate(t.expiresDate);
+			transaction.revocationTime = toDate(t.revocationDate);
+			if (transaction.orderId != null && processedOrderIds.add(transaction.orderId)) {
+				List<AdminService.Purchase> found = orderManagementService.searchPurchases(transaction.orderId,
+						PURCHASES_PER_TRANSACTION);
+				for (AdminService.Purchase p : found) {
+					if (transaction.orderId.equals(p.orderId)) {
+						res.purchases.add(p);
+					}
+				}
+			}
+			transaction.stored = transaction.orderId != null
+					&& res.purchases.stream().anyMatch(p -> transaction.orderId.equals(p.orderId));
+			res.transactions.add(transaction);
+		}
+		return res;
+	}
+
+	private static Date toDate(Long ms) {
+		return ms != null && ms > 0 ? new Date(ms) : null;
+	}
+}

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/user/OrderManagementController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/user/OrderManagementController.java
@@ -8,6 +8,7 @@ import net.osmand.server.api.repo.CloudUsersRepository;
 import net.osmand.server.api.services.AdminService;
 import net.osmand.server.api.services.AdminService.Purchase;
 import net.osmand.server.WebSecurityConfiguration;
+import net.osmand.server.api.services.AppleOrderLookupService;
 import net.osmand.server.api.services.OrderManagementService;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,9 @@ public class OrderManagementController {
 
 	@Autowired
 	OrderManagementService orderManagementService;
+
+	@Autowired
+	AppleOrderLookupService appleOrderLookupService;
 
 	@Autowired
 	private CloudUsersRepository usersRepository;
@@ -66,11 +70,7 @@ public class OrderManagementController {
 			return Collections.emptyList();
 		}
 		List<AdminService.Purchase> purchases = orderManagementService.searchPurchases(trimmed, limit);
-		for (Purchase p : purchases) {
-			if (p.purchaseToken != null && p.purchaseToken.length() > 50) {
-				p.purchaseToken = p.purchaseToken.substring(0, 50) + "...";
-			}
-		}
+		purchases.forEach(OrderManagementController::shortenToken);
 		if (purchases.isEmpty()) {
 			List<CloudUsersRepository.CloudUser> users = usersRepository.findByEmailStartingWith(text, PageRequest.of(0, limit));
 			if (!users.isEmpty()) {
@@ -96,6 +96,24 @@ public class OrderManagementController {
 			}
 		}
 		return purchases;
+	}
+
+	/**
+	 * Resolves an Apple order id from the customer's receipt email (MXXXXXXXXX) into the purchases we
+	 * store: Apple purchases are keyed by original_transaction_id, which is not in that email.
+	 */
+	@GetMapping(value = "/orders/apple-lookup", produces = MediaType.APPLICATION_JSON_VALUE)
+	@ResponseBody
+	public ResponseEntity<AppleOrderLookupService.AppleOrderLookup> appleOrderLookup(
+			@RequestParam(name = "orderId") String orderId) {
+		if (StringUtils.isBlank(orderId)) {
+			return ResponseEntity.badRequest().build();
+		}
+		AppleOrderLookupService.AppleOrderLookup lookup = appleOrderLookupService.lookup(orderId.trim());
+		for (Purchase p : lookup.purchases) {
+			shortenToken(p);
+		}
+		return ResponseEntity.ok(lookup);
 	}
 
 	@GetMapping("/skus")
@@ -161,6 +179,12 @@ public class OrderManagementController {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Order version already exists");
 		}
 		return ResponseEntity.ok("Order version created");
+	}
+
+	private static void shortenToken(Purchase p) {
+		if (p.purchaseToken != null && p.purchaseToken.length() > 50) {
+			p.purchaseToken = p.purchaseToken.substring(0, 50) + "...";
+		}
 	}
 
 	@GetMapping("/generate-order-id")

--- a/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/purchases/AppStoreOrderLookupHelper.java
+++ b/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/purchases/AppStoreOrderLookupHelper.java
@@ -1,0 +1,260 @@
+package net.osmand.purchases;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Client for the App Store Server API "Look Up Order ID" endpoint:
+ * https://developer.apple.com/documentation/appstoreserverapi/look-up-order-id
+ * <p>
+ * Apple emails the customer a receipt that contains an order id (looks like MXXXXXXXXX). That id is
+ * not part of the app receipt, so it never reaches supporters_device_sub / supporters_device_iap,
+ * where Apple purchases are keyed by original_transaction_id. This helper converts an order id into
+ * the transactions behind it, so support can find (or register) the purchase by what the user has.
+ * <p>
+ * Configuration (App Store Connect -> Users and Access -> Integrations -> In-App Purchase key):
+ * <ul>
+ * <li>IOS_STORE_API_KEY - base64 body of the .p8 key (PKCS#8, without the BEGIN/END lines)</li>
+ * <li>IOS_STORE_API_KEY_ID - key id of that key</li>
+ * <li>IOS_STORE_API_ISSUER_ID - issuer id shown above the key list</li>
+ * </ul>
+ * The lookup endpoint is not available in the sandbox environment, production orders only.
+ */
+public class AppStoreOrderLookupHelper {
+
+	public static final String LOOKUP_URL = "https://api.storekit.itunes.apple.com/inApps/v1/lookup/";
+
+	// https://developer.apple.com/documentation/appstoreserverapi/orderlookupstatus
+	public static final int ORDER_VALID = 0;
+	public static final int ORDER_INVALID = 1;
+
+	public static final String ENV_KEY = "IOS_STORE_API_KEY";
+	public static final String ENV_KEY_ID = "IOS_STORE_API_KEY_ID";
+	public static final String ENV_ISSUER_ID = "IOS_STORE_API_ISSUER_ID";
+
+	private static final String AUDIENCE = "appstoreconnect-v1";
+	// Apple rejects tokens valid for more than 60 minutes
+	private static final long TOKEN_LIFETIME_SEC = 20 * 60;
+	private static final int TIMEOUT_MS = 20000;
+
+	public static class OrderLookupResult {
+		public int status;
+		public String message;
+		public List<AppStoreTransaction> transactions = new ArrayList<>();
+
+		public boolean isValidOrder() {
+			return status == ORDER_VALID;
+		}
+	}
+
+	/**
+	 * Decoded JWSTransaction payload:
+	 * https://developer.apple.com/documentation/appstoreserverapi/jwstransactiondecodedpayload
+	 */
+	public static class AppStoreTransaction {
+		public String originalTransactionId;
+		public String transactionId;
+		public String productId;
+		public String type;
+		public String inAppOwnershipType;
+		public String environment;
+		public String storefront;
+		public Long purchaseDate;
+		public Long originalPurchaseDate;
+		public Long expiresDate;
+		public Long revocationDate;
+		public Integer revocationReason;
+	}
+
+	public boolean isConfigured() {
+		return !isEmpty(System.getenv(ENV_KEY)) && !isEmpty(System.getenv(ENV_KEY_ID))
+				&& !isEmpty(System.getenv(ENV_ISSUER_ID));
+	}
+
+	/**
+	 * @param orderId order id from the customer's Apple receipt email
+	 * @return transactions Apple knows for that order id; an unknown order id is reported as
+	 * {@link #ORDER_INVALID} instead of an exception
+	 */
+	public OrderLookupResult lookupOrder(String orderId) throws IOException {
+		if (isEmpty(orderId)) {
+			throw new IllegalArgumentException("Order id is empty");
+		}
+		if (!isConfigured()) {
+			throw new IllegalStateException(String.format("App Store Server API is not configured (%s, %s, %s)",
+					ENV_KEY, ENV_KEY_ID, ENV_ISSUER_ID));
+		}
+		String token;
+		try {
+			token = generateToken();
+		} catch (Exception e) {
+			throw new IOException("Cannot sign App Store Server API token: " + e.getMessage(), e);
+		}
+		JsonObject response = httpGet(LOOKUP_URL + orderId.trim(), token);
+		OrderLookupResult result = new OrderLookupResult();
+		JsonElement status = response.get("status");
+		result.status = status != null && !status.isJsonNull() ? status.getAsInt() : ORDER_INVALID;
+		if (!result.isValidOrder()) {
+			result.message = "Apple does not know this order id";
+			return result;
+		}
+		JsonElement signedTransactions = response.get("signedTransactions");
+		if (signedTransactions != null && signedTransactions.isJsonArray()) {
+			for (JsonElement jws : signedTransactions.getAsJsonArray()) {
+				AppStoreTransaction transaction = parseTransaction(decodeJwsPayload(jws.getAsString()));
+				if (transaction != null) {
+					result.transactions.add(transaction);
+				}
+			}
+		}
+		return result;
+	}
+
+	private AppStoreTransaction parseTransaction(JsonObject payload) {
+		if (payload == null) {
+			return null;
+		}
+		AppStoreTransaction transaction = new AppStoreTransaction();
+		transaction.originalTransactionId = getString(payload, "originalTransactionId");
+		transaction.transactionId = getString(payload, "transactionId");
+		transaction.productId = getString(payload, "productId");
+		transaction.type = getString(payload, "type");
+		transaction.inAppOwnershipType = getString(payload, "inAppOwnershipType");
+		transaction.environment = getString(payload, "environment");
+		transaction.storefront = getString(payload, "storefront");
+		transaction.purchaseDate = getLong(payload, "purchaseDate");
+		transaction.originalPurchaseDate = getLong(payload, "originalPurchaseDate");
+		transaction.expiresDate = getLong(payload, "expiresDate");
+		transaction.revocationDate = getLong(payload, "revocationDate");
+		JsonElement reason = payload.get("revocationReason");
+		transaction.revocationReason = reason != null && !reason.isJsonNull() ? reason.getAsInt() : null;
+		return transaction;
+	}
+
+	/**
+	 * Signed payloads are read without verifying the certificate chain: they are received over TLS
+	 * from Apple in response to a request signed with our own private key and are only displayed to
+	 * admins, never used as a proof of purchase on its own.
+	 */
+	public static JsonObject decodeJwsPayload(String jws) {
+		if (isEmpty(jws)) {
+			return null;
+		}
+		String[] parts = jws.split("\\.");
+		if (parts.length != 3) {
+			return null;
+		}
+		String payload = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+		JsonElement parsed = new JsonParser().parse(payload);
+		return parsed.isJsonObject() ? parsed.getAsJsonObject() : null;
+	}
+
+	private String generateToken() throws Exception {
+		String keyId = System.getenv(ENV_KEY_ID);
+		String issuerId = System.getenv(ENV_ISSUER_ID);
+		long now = System.currentTimeMillis() / 1000L;
+
+		JsonObject header = new JsonObject();
+		header.addProperty("alg", "ES256");
+		header.addProperty("kid", keyId);
+		header.addProperty("typ", "JWT");
+
+		JsonObject payload = new JsonObject();
+		payload.addProperty("iss", issuerId);
+		payload.addProperty("iat", now);
+		payload.addProperty("exp", now + TOKEN_LIFETIME_SEC);
+		payload.addProperty("aud", AUDIENCE);
+		payload.addProperty("bid", ReceiptValidationHelper.IOS_MAPS_BUNDLE_ID);
+
+		Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+		String signingInput = encoder.encodeToString(header.toString().getBytes(StandardCharsets.UTF_8))
+				+ "." + encoder.encodeToString(payload.toString().getBytes(StandardCharsets.UTF_8));
+
+		byte[] pkcs8 = Base64.getDecoder().decode(cleanupKey(System.getenv(ENV_KEY)));
+		PrivateKey privateKey = KeyFactory.getInstance("EC").generatePrivate(new PKCS8EncodedKeySpec(pkcs8));
+		// P1363 is the (r || s) format required by JWS ES256, unlike the default DER encoding
+		Signature ecdsa = Signature.getInstance("SHA256withECDSAinP1363Format");
+		ecdsa.initSign(privateKey);
+		ecdsa.update(signingInput.getBytes(StandardCharsets.UTF_8));
+
+		return signingInput + "." + encoder.encodeToString(ecdsa.sign());
+	}
+
+	// tolerate a .p8 pasted with its PEM header/footer and line breaks
+	private static String cleanupKey(String key) {
+		return key.replace("-----BEGIN PRIVATE KEY-----", "").replace("-----END PRIVATE KEY-----", "")
+				.replaceAll("\\s", "");
+	}
+
+	private JsonObject httpGet(String url, String token) throws IOException {
+		HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+		try {
+			connection.setRequestMethod("GET");
+			connection.setRequestProperty("Authorization", "Bearer " + token);
+			connection.setRequestProperty("Accept", "application/json");
+			connection.setConnectTimeout(TIMEOUT_MS);
+			connection.setReadTimeout(TIMEOUT_MS);
+
+			int code = connection.getResponseCode();
+			// 404 with errorCode 4040005 is Apple's answer for an order id it has no transactions for
+			InputStream in = code == HttpURLConnection.HTTP_OK ? connection.getInputStream() : connection.getErrorStream();
+			String body = in != null ? read(in) : "";
+			if (code == HttpURLConnection.HTTP_OK) {
+				JsonElement parsed = new JsonParser().parse(body);
+				if (!parsed.isJsonObject()) {
+					throw new IOException("Unexpected App Store Server API response: " + body);
+				}
+				return parsed.getAsJsonObject();
+			}
+			if (code == HttpURLConnection.HTTP_NOT_FOUND) {
+				JsonObject notFound = new JsonObject();
+				notFound.addProperty("status", ORDER_INVALID);
+				return notFound;
+			}
+			throw new IOException(String.format("App Store Server API error %d: %s", code, body));
+		} finally {
+			connection.disconnect();
+		}
+	}
+
+	private static String read(InputStream in) throws IOException {
+		StringBuilder builder = new StringBuilder();
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				builder.append(line);
+			}
+		}
+		return builder.toString();
+	}
+
+	private static String getString(JsonObject obj, String field) {
+		JsonElement el = obj.get(field);
+		return el != null && !el.isJsonNull() ? el.getAsString() : null;
+	}
+
+	private static Long getLong(JsonObject obj, String field) {
+		JsonElement el = obj.get(field);
+		return el != null && !el.isJsonNull() ? el.getAsLong() : null;
+	}
+
+	private static boolean isEmpty(String s) {
+		return s == null || s.isEmpty();
+	}
+}


### PR DESCRIPTION
## Problem

Apple purchases are keyed in `supporters_device_sub` / `supporters_device_iap` by
`original_transaction_id` (`SubscriptionController.purchased()` stores the iOS `purchaseToken`
parameter, i.e. the StoreKit original transaction id, as `orderid`).

The receipt Apple emails to the customer contains a different identifier — an Apple order id that
looks like `MXXXXXXXXX` — and that id is not part of the app receipt, so it is never stored anywhere
on our side. When a user writes to support quoting the number from their email, order management
finds nothing, and there is currently no way to get from that number to the purchase.

## What this adds

`AppStoreOrderLookupHelper` — a client for the App Store Server API
[Look Up Order ID](https://developer.apple.com/documentation/appstoreserverapi/look-up-order-id)
endpoint (`GET /inApps/v1/lookup/{orderId}`), which is exactly Apple's answer for this case: it
returns the signed transactions behind an order id, including `originalTransactionId`.

- ES256 JWT is signed in-process (`SHA256withECDSAinP1363Format`, no new dependency), the same way
  `SubscriptionController.generateOfferSignature` already signs with an App Store key.
- `AppleOrderLookupService` resolves the order id and then looks up each `originalTransactionId`
  through the existing `OrderManagementService.searchPurchases`, so the admin sees both what Apple
  knows and what we store, and which transactions we are missing.
- `GET /admin/order-mgmt/orders/apple-lookup?orderId=...` exposes it (already behind
  `ROLE_ADMIN`/`ROLE_SUPPORT` via `/admin/order-mgmt/**`).

UI side is a separate PR in web-server-config: osmandapp/web-server-config#209

## Configuration

Needs an **In-App Purchase key** (App Store Connect → Users and Access → Integrations → In-App
Purchase), which we do not have yet — the existing `IOS_SUBSCRIPTION_KEY` is the subscription-offer
signing key and `IOS_SUBSCRIPTION_SECRET` is the legacy `verifyReceipt` shared secret, neither works
here.

Only the private key goes to the server environment:

- `IOS_STORE_API_KEY` — base64 body of the `.p8` file (a full PEM with header/footer is accepted too)

The key id and the issuer id are not secrets and are kept as `KEY_ID` / `ISSUER_ID` constants in
`AppStoreOrderLookupHelper`, currently empty and marked with a TODO — they have to be filled in when
the key is generated. `IOS_STORE_API_KEY_ID` / `IOS_STORE_API_ISSUER_ID` override the constants
without a redeploy, e.g. while rotating the key.

Until the key is in place the endpoint answers `configured: false` and the UI says so. The lookup endpoint
is production-only, Apple does not serve it in the sandbox.

## Testing

- JWT generation verified locally against a throwaway P-256 key: header/payload match Apple's
  required shape (`alg ES256`, `kid`, `iss`, `aud: appstoreconnect-v1`, `bid`), signature is 64 bytes
  in P1363 form and verifies with the matching public key; both a raw base64 `.p8` body and a PEM
  with header/footer are accepted.
- Key id / issuer resolution checked in all three states: constants empty and no env (reports not
  configured), constants filled (used as is), env set (overrides the constants).
- JWS payload decoding checked on a transaction payload of the shape Apple returns; malformed input
  returns `null` instead of throwing.
- **Not** verified against the live Apple endpoint — that needs the In-App Purchase key above. The
  full Spring app was not built either (the Gradle build needs the sibling android checkouts), the
  new service/controller code was reviewed by hand.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Check the server and iOS code and tell me whether all Apple purchases end up in
   https://osmand.net/admin/order-mgmt or something is skipped.
2. Users get a transaction number in an email from Apple — could we search by it in the order
   management UI?
3. Add the App Store Server API "Look Up Order ID" endpoint to the server so we can type an order id
   in and show the result in the web; open a draft pull request and explain it.

Decided by the agent, not requested explicitly:
- Env var names (`IOS_STORE_API_KEY`, `IOS_STORE_API_KEY_ID`, `IOS_STORE_API_ISSUER_ID`) and the
  choice to keep the helper in `OsmAndServerUtilities` next to the other store helpers.
- Keeping key id and issuer id in code with env override was asked for (to keep the server config to
  a single line); leaving them as empty constants with a TODO, since the key does not exist yet, is
  the agent's choice.
- Signing the JWT with the JDK (`SHA256withECDSAinP1363Format`) instead of adding a JWT dependency.
- Not verifying Apple's JWS certificate chain: the payloads are read over TLS from a request signed
  with our own key and are only shown to admins, never used as proof of purchase. Documented in the
  helper's javadoc; worth revisiting if this data is ever used to grant anything.
- Reusing `searchPurchases` for the DB side and extracting the existing purchase-token shortening
  into `shortenToken`.
- Which transaction fields to surface (product id, transaction ids, dates, type, environment,
  storefront, revocation).

