### PR TITLE
Add local_authority to address boundaries

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexAddressCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/IndexAddressCreator.java
@@ -410,9 +410,10 @@ public class IndexAddressCreator extends AbstractIndexPartCreator {
 		CityType ct = CityType.valueFromEntity(e);
 		// if a place that has addr_place is a neighbourhood mark it as a suburb (made for the suburbs of Venice)
 		boolean administrative = "administrative".equals(e.getTag(OSMTagKey.BOUNDARY));
+		boolean local_authority = "local_authority".equals(e.getTag(OSMTagKey.BOUNDARY));
 		boolean census = "census".equals(e.getTag(OSMTagKey.BOUNDARY));
 //		boolean postalCode = "postal_code".equals(e.getTag(OSMTagKey.BOUNDARY));
-		if (administrative || census || postalCode || ct != null) {
+		if (administrative || census || postalCode || ct != null || local_authority) {
 			if (e instanceof Way && visitedBoundaryWays.contains(e.getId())) {
 				return null;
 			}


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd/issues/25940
_Add missing boundaries to Adress section (probably national parks?)_

No AI

1) Selected from france_occitania_ariege_europe.pbf all objects contains tags: boundary, name, wikidata
2) Made search test in SpatialSearchTestAndDocs to find missed results.
Found missed results ``boundry=politic, religion, local_authority``
Ignored: ``boundry=politic, religion``
3) Added to address boundary local_authority
4) Generated France_occitania_ariege_europe.obf
5) Check if boundary exists:
```
ivan@Mac-mini-Ivan mapcreator % ./inspector.sh -vaddress -vcities -vstreetgroups ../maps/France_occitania_ariege_europe.obf | grep "Haute Ariège" 
вер. 04, 2026 4:50:07 ПП net.osmand.osm.MapRenderingTypes initFromInputStream
INFO: Time to init poi types 34
		'Communauté de communes de la Haute Ariège' [R 7008877], 0 street(s) size 0 bytes 42,83363, 1,35097 - 42,57324, 2,17581
```
6) Made search test in SpatialSearchTestAndDocs to find missed results.
For query ``Communauté de communes de la Haute Ariège`` - before was 5 results, after - 92.
But no ``Communauté de communes de la Haute Ariège`` in the main result, only as secondary inside other results.
So need to fix search algorithm (?)


National parks test:

| Park | OSM | Wikidata | Rank/Results | Type | Dist. |
|---|---|---|---|---|---|
| Parque Nacional de Doñana | [rel/10036176](https://www.openstreetmap.org/relation/10036176) | [Q463141](https://www.wikidata.org/wiki/Q463141) | 6/9 | Nature reserve | 230.7 km |
| Parque Nacional de Sierra Nevada | [rel/4829086](https://www.openstreetmap.org/relation/4829086) | [Q1969050](https://www.wikidata.org/wiki/Q1969050) | 6/9 | POI Wiki place | – |
| Kootenay National Park | [way/673733022](https://www.openstreetmap.org/way/673733022) | [Q903323](https://www.wikidata.org/wiki/Q903323) | 1/18 | Nature reserve | 161.0 km |
| Glacier National Park | [rel/3961485](https://www.openstreetmap.org/relation/3961485) | [Q1161253](https://www.wikidata.org/wiki/Q1161253) | 3/13 | Nature reserve | 165.2 km |
| Yoho National Park | [rel/9368703](https://www.openstreetmap.org/relation/9368703) | [Q828404](https://www.wikidata.org/wiki/Q828404) | 6/11 | Nature reserve | 166.3 km |
| Mount Revelstoke National Park | [rel/3961479](https://www.openstreetmap.org/relation/3961479) | [Q862265](https://www.wikidata.org/wiki/Q862265) | 1/1 | Nature reserve | 168.1 km |
| Pacific Rim National Park Reserve of Canada | [rel/2017391](https://www.openstreetmap.org/relation/2017391) | [Q1756401](https://www.wikidata.org/wiki/Q1756401) | 1/16 | Nature reserve | 74.3 km |
| Gwaii Haanas National Park Reserve & Haida Heritage Site | [rel/3960666](https://www.openstreetmap.org/relation/3960666) | [Q862285](https://www.wikidata.org/wiki/Q862285) | 1/1 | Wikipedia | 139.8 km |
| Waterton Lakes National Park | [rel/6395476](https://www.openstreetmap.org/relation/6395476) | [Q902778](https://www.wikidata.org/wiki/Q902778) | 1/6 | Nature reserve | 173.3 km |
| Banff National Park | [rel/6365995](https://www.openstreetmap.org/relation/6365995) | [Q41858](https://www.wikidata.org/wiki/Q41858) | 1/3 | Nature reserve | 148.3 km |
| Jasper National Park | [rel/6395738](https://www.openstreetmap.org/relation/6395738) | [Q503429](https://www.wikidata.org/wiki/Q503429) | 1/9 | Nature reserve | 160.4 km |

**8/11** top-1 live on osmand.net · **2/2** correct in local OBF index (Spain sample) · exceptions: Doñana (rank 6), Glacier (rank 3), Yoho (rank 6) — all outranked by same-name/nearby POIs, not index errors.

Full report: https://claude.ai/code/artifact/c2f67560-40e0-4447-9d4d-fdb6507c629a