### PR TITLE
Coastline test: render the tiles with the OpenGL engine on -renderer=opengl

### DIFF
--- a/.claude/skills/coastline-rendering-test/SKILL.md
+++ b/.claude/skills/coastline-rendering-test/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: coastline-rendering-test
-description: Run or debug the coastline rendering test (CoastlineRenderingTester / `utilities.sh test-coastline-rendering`) that compares locally rendered tiles against tile.osmand.net and reports water mask differences. Use when working on coastline issues, on the Web_Ocean_Tiles_Test Jenkins job, on coastline-tests.json, or when the test is slow, crashes on a map, or reports unexpected failures.
+description: Run or debug the coastline rendering test (CoastlineRenderingTester / `utilities.sh test-coastline-rendering`) that compares locally rendered tiles against tile.osmand.net and reports water mask differences, with either the legacy (v1) renderer or the OpenGL core one (v2, `-renderer=opengl`). Use when working on coastline issues, on the Web_Ocean_Tiles_Test Jenkins job, on coastline-tests.json, when comparing the two rendering engines, or when the test is slow, crashes on a map, or reports unexpected failures.
 ---
 
 # Coastline rendering test
 
-Renders tiles with the legacy native renderer and compares the water mask against the reference
-`https://tile.osmand.net/hd/{z}/{x}/{y}.png`. Exit code 0 = clean, 2 = problems reproduced,
-1 = could not run. Writes `index.html` + `summary.json` into the output folder, images for failed
-tiles only.
+Renders tiles with the legacy native renderer (v1) or with OsmAndCore (v2, `-renderer=opengl`) and
+compares the water mask against the reference `https://tile.osmand.net/hd/{z}/{x}/{y}.png`. Exit
+code 0 = clean, 2 = problems reproduced, 1 = could not run. Writes `index.html` + `summary.json`
+into the output folder, images for failed tiles only.
 
 - Utility: `java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java`
   (all options are documented in its class javadoc - read it before guessing a flag).
@@ -38,6 +38,46 @@ unzip -q OsmAndMapCreator/build/distributions/OsmAndMapCreator.zip -d /tmp/mc
 `-native` is only needed when the bundled `osmand-<os>-<arch>.lib` is missing from the zip, which
 happens with `--offline` because `downloadCoreJni` is skipped. On the build server pass nothing -
 the bundled library is used, and `null` is the value that loads it.
+
+## The OpenGL (v2) engine
+
+`-renderer=opengl` renders every tile with OsmAndCore instead of the legacy library - the engine the
+apps actually draw with - and changes nothing else: same cases, same water masks, same report, same
+exit codes, so the two runs are directly comparable. The report and `summary.json` carry the
+`renderer` they were produced with.
+
+```bash
+/tmp/mc/utilities.sh test-coastline-rendering -renderer=opengl -maps.dir=$HOME/osmand/maps \
+  -out=/tmp/report-gl -eyepiece=<repo>/binaries/<platform>/Release/eyepiece
+```
+
+It drives the `eyepiece` tool of core as a co-process through its batch tile mode
+(`-tiles=- -tilesOutputDir=...`, tiles as `z/x/y` lines on stdin, one `TILE z/x/y <file>` answer
+per tile). Things worth knowing:
+
+- **The binary needs the batch tile mode**, i.e. core with `-tiles=`. Check with
+  `strings eyepiece | grep tilesOutputDir` before blaming the tester; the published
+  `https://builder.osmand.net/binaries/amd64-linux-clang/eyepiece_standalone` is the build server's
+  copy and is the one to use on Jenkins (it is linked with EGL - `EGL_PLATFORM_DEVICE_EXT` - so it
+  renders headless, no X server and no `xvfb-run` needed).
+- `-eyepiece=` is autodetected from `binaries/` of a repository checkout and from the PATH.
+  `-stylesPath=` defaults to the styles built into core, `-eyepieceLog=true` echoes everything
+  eyepiece prints.
+- **No legacy library, no fonts folder and no `indexes.cache`** are used in this mode - core does
+  all of that itself. `-native=` is ignored.
+- The set of maps is fixed when the process starts, so a case that opens or closes a map restarts
+  eyepiece; the maps are handed over as a folder of symlinks in `<out>/opengl-maps`. Watch the
+  `Started eyepiece #N` lines: with `-load=case` there is one per case, which is normal, but a
+  restart with a thousand maps loaded costs the whole obf scan again.
+- **It is ~20x slower per tile than the legacy renderer** - measured 0.7 s/tile against 25 ms/tile
+  (276 fixed case tiles: 193 s against 12 s). A 10 000 tile run is hours of rendering, so on the
+  build server keep the OpenGL run to the fixed cases or a small `-randomTilesK`.
+
+Measured on the 276 fixed case tiles (September 2026): v2 fixes #25119 (Goa flooding: 4 failed
+tiles against 0) and most of #24376, reproduces #25618 (St. Lawrence, 23 failed tiles) exactly like
+v1, and fails one San Francisco tile that v1 draws correctly. The two `seamarksInland` cases fail
+identically in both, which is the expected sanity check - they are a map data problem and have
+nothing to do with the renderer.
 
 ## The one number that explains a slow run
 

--- a/cpp-tools/map-rasterizer/main.cpp
+++ b/cpp-tools/map-rasterizer/main.cpp
@@ -87,6 +87,9 @@ void printUsage(const std::string& warning /*= std::string()*/)
     tcout << xT("\t-outputRasterWidth=size_in_pixels") << std::endl;
     tcout << xT("\t-outputRasterHeight=size_in_pixels") << std::endl;
     tcout << xT("\t-outputImageFilename=path/with/filename and/or -outputJSONFilename=path/with/filename (without extension)") << std::endl;
+    tcout << xT("\t[-tiles=path/to/list/of/z/x/y/tiles or -tiles=- to read them from stdin,") << std::endl;
+    tcout << xT("\t -tilesOutputDir=path/to/write/z/x/y.png, -tileSize=256 - batch tile mode,") << std::endl;
+    tcout << xT("\t one image per tile, answering with a 'TILE z/x/y file' line for each of them]") << std::endl;
     tcout << xT("\t[-outputImageFormat=png|jpeg]") << std::endl;
     tcout << xT("\t[-latLon=46.95:7.45 or -target31=x:y]") << std::endl;
     tcout << xT("\t[-targetOnRelief]") << std::endl;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
@@ -47,8 +47,9 @@ import net.osmand.util.MapUtils;
 import net.osmand.util.MapsCollection;
 
 /**
- * Renders map tiles with the native (legacy) renderer and compares their <b>water mask</b> with the
- * water mask of the reference raster tiles of {@code https://tile.osmand.net/hd/{z}/{x}/{y}.png},
+ * Renders map tiles with the native (legacy, v1) renderer or with the OpenGL core renderer (v2, see
+ * {@code renderer}) and compares their <b>water mask</b> with the water mask of the reference raster
+ * tiles of {@code https://tile.osmand.net/hd/{z}/{x}/{y}.png},
  * to reproduce the coastline problems of
  * <a href="https://github.com/osmandapp/OsmAnd-Issues/issues/3291">Epic - Coastline issues</a>.
  *
@@ -70,6 +71,8 @@ import net.osmand.util.MapsCollection;
  * OsmAndMapCreator/utilities.sh test-coastline-rendering -maps.dir=/var/maps
  * # every tile of the world between two zooms, with every map of the maps folder
  * OsmAndMapCreator/utilities.sh test-coastline-rendering -scan -minzoom=1 -maxzoom=10 -maps.dir=/var/maps
+ * # the same cases through the OpenGL engine of the apps instead of the legacy one
+ * OsmAndMapCreator/utilities.sh test-coastline-rendering -renderer=opengl -maps.dir=/var/maps
  * </pre>
  * Exit code: <b>0</b> - everything matches the reference, <b>2</b> - problems were reproduced,
  * <b>1</b> - the tester could not run (native library could not be loaded, no maps, broken json).
@@ -105,8 +108,17 @@ import net.osmand.util.MapsCollection;
  * <li>{@code out} - output folder, default {@code build/coastline-tiles};</li>
  * <li>{@code save} - {@code failed} (default) writes the png tiles of the failed tiles only,
  * {@code all} writes everything, {@code none} keeps statistics only;</li>
+ * <li>{@code renderer} - {@code legacy} (default) draws the tiles with the native library, the same
+ * v1 engine the tile server runs; {@code opengl} draws them with OsmAndCore (v2 - the engine of the
+ * apps) by driving the {@code eyepiece} tool. Everything else - the cases, the water masks, the
+ * report and the exit codes - is the same, so the two runs are directly comparable;</li>
+ * <li>{@code eyepiece}, {@code stylesPath} - only for {@code -renderer=opengl}: path to the
+ * eyepiece binary (autodetected in {@code binaries} of a repository checkout and on the PATH) and
+ * the folder with the {@code *.render.xml} styles (by default the styles built into OsmAndCore).
+ * {@code -eyepieceLog=true} echoes everything eyepiece prints;</li>
  * <li>{@code native} - path to {@code libosmand.dylib/so/dll}; by default the library bundled into
- * OsmAndMapCreator is used, a local repository checkout picks it up from {@code core-legacy};</li>
+ * OsmAndMapCreator is used, a local repository checkout picks it up from {@code core-legacy}.
+ * Ignored by {@code -renderer=opengl}, which needs no legacy library at all;</li>
  * <li>{@code fonts}, {@code style} - renderer setup, autodetected;</li>
  * <li>{@code threads} - parallel reference tile downloads, default 16. Rendering itself is single
  * threaded, this only controls how many reference tiles are fetched at once - raise it if the
@@ -116,7 +128,9 @@ import net.osmand.util.MapsCollection;
  * {@code coastline-reference} in the current folder. It is reused by every run, so a rerun only
  * downloads the tiles it has not seen yet - delete the folder to force a refetch;</li>
  * <li>{@code referenceCache} - {@code false} to delete a reference tile once it was compared;</li>
- * <li>{@code tileSize}, {@code tolerance} - size of the compared tile and the mask tolerance.</li>
+ * <li>{@code tileSize}, {@code tolerance} - size of the rendered tile and the mask tolerance. The
+ * reference tile is scaled to the rendered one, and {@code tileSize} is honoured by
+ * {@code -renderer=opengl} only - the legacy renderer always draws 256 px per tile.</li>
  * </ul>
  */
 public class CoastlineRenderingTester {
@@ -176,6 +190,9 @@ public class CoastlineRenderingTester {
 	static final String GROUP_FIXED = "Fixed cases of coastline-tests.json";
 	static final String GROUP_RANDOM = "Random tiles";
 	static final String GROUP_SCAN = "Full scan";
+
+	/** {@code renderer} - the legacy native renderer (v1) and the OpenGL core renderer (v2). */
+	static final String RENDERER_LEGACY = "legacy", RENDERER_OPENGL = "opengl";
 
 	private static final String BUNDLED_CASES = "/net/osmand/render/coastline-tests.json";
 	private static final String CHECK_SEAMARKS_INLAND = "seamarksInland";
@@ -318,6 +335,7 @@ public class CoastlineRenderingTester {
 
 	/** Result of a whole run, also written to {@code summary.json}. */
 	public static class RunResult {
+		public String renderer;
 		public String style;
 		public String mapsDir;
 		public int loadedMaps;
@@ -345,12 +363,14 @@ public class CoastlineRenderingTester {
 	private final int threads;
 	private final boolean writeHtml;
 	private final int flushEvery;
+	private final boolean openGl;
 
 	private CasesFile casesFile;
 	private RunResult result;
 	private int tilesSinceFlush;
 	private long lastFlush;
 	private NativeJavaRendering renderer;
+	private EyePieceTileRenderer eyePiece;
 	private final Set<String> initializedMaps = new LinkedHashSet<>();
 	private final List<TileResult> reported = new ArrayList<>();
 	private ExecutorService downloadPool;
@@ -377,6 +397,11 @@ public class CoastlineRenderingTester {
 		this.threads = Integer.parseInt(opt("threads", "16"));
 		this.writeHtml = Boolean.parseBoolean(opt("html", "true"));
 		this.flushEvery = Integer.parseInt(opt("flushEvery", "1000"));
+		this.openGl = RENDERER_OPENGL.equalsIgnoreCase(opt("renderer", RENDERER_LEGACY));
+		if (!openGl && !RENDERER_LEGACY.equalsIgnoreCase(opt("renderer", RENDERER_LEGACY))) {
+			throw new IllegalArgumentException("-renderer must be " + RENDERER_LEGACY + " or "
+					+ RENDERER_OPENGL + " but was " + opt("renderer", RENDERER_LEGACY));
+		}
 	}
 
 	private String opt(String name, String def) {
@@ -432,6 +457,7 @@ public class CoastlineRenderingTester {
 		downloadPool = Executors.newFixedThreadPool(threads);
 
 		result = new RunResult();
+		result.renderer = openGl ? RENDERER_OPENGL : RENDERER_LEGACY;
 		result.style = opt("style", "default.render.xml");
 		result.mapsDir = mapsDir.getAbsolutePath();
 		result.startedAt = start;
@@ -447,6 +473,9 @@ public class CoastlineRenderingTester {
 			}
 		} finally {
 			downloadPool.shutdownNow();
+			if (eyePiece != null) {
+				eyePiece.close();
+			}
 		}
 		result.loadedMaps = initializedMaps.size();
 		recomputeTotals();
@@ -687,19 +716,14 @@ public class CoastlineRenderingTester {
 
 	// ----------------------------------------------------------------- renderer setup
 
-	private void initRenderer() throws Exception {
+	/** The v1 engine: {@code libosmand}, the same renderer the tile server runs today. */
+	private void initLegacyRenderer(String style) throws Exception {
 		// null lets NativeJavaRendering load the library bundled into OsmAndMapCreator
 		File nativeLib = findNativeLibrary();
 		File fonts = findFonts();
-		String style = opt("style", "default.render.xml");
 		System.out.println("Native library : " + (nativeLib == null
 				? "bundled with OsmAndMapCreator" : nativeLib.getAbsolutePath()));
 		System.out.println("Fonts          : " + (fonts == null ? "none" : fonts.getAbsolutePath()));
-		System.out.println("Maps           : " + mapsDir.getAbsolutePath());
-		System.out.println("Output         : " + outputDir.getAbsolutePath());
-		System.out.println("Reference cache: " + referenceCacheDir.getAbsolutePath()
-				+ " (" + countCachedReferences() + " tiles kept from the previous runs)");
-		System.out.println("Style          : " + style);
 
 		renderer = NativeJavaRendering.getDefault(nativeLib == null ? null : nativeLib.getAbsolutePath(), null,
 				fonts == null ? null : fonts.getAbsolutePath());
@@ -708,6 +732,40 @@ public class CoastlineRenderingTester {
 					+ (nativeLib == null ? ", pass -native=<path to libosmand.dylib/so/dll>" : ": " + nativeLib));
 		}
 		renderer.loadRuleStorage(style, "density=1,textScale=1");
+	}
+
+	/**
+	 * The v2 engine: OsmAndCore driven through the {@code eyepiece} tool, which needs no native
+	 * library of the distribution, no fonts folder and no indexes cache - core does all of that
+	 * itself. The style is resolved by name ({@code default.render.xml} is {@code default}), from
+	 * {@code -stylesPath} when it is given and from the styles built into core otherwise.
+	 */
+	private void initOpenGlRenderer(String style) {
+		File binary = findEyePiece();
+		File stylesPath = findStyles();
+		String styleName = style.endsWith(".render.xml")
+				? style.substring(0, style.length() - ".render.xml".length()) : style;
+		System.out.println("eyepiece       : " + binary.getAbsolutePath());
+		System.out.println("Styles path    : " + (stylesPath == null
+				? "built into OsmAndCore" : stylesPath.getAbsolutePath()));
+		eyePiece = new EyePieceTileRenderer(binary, stylesPath, styleName, tileSize, outputDir,
+				Boolean.parseBoolean(opt("eyepieceLog", "false")));
+	}
+
+	private void initRenderer() throws Exception {
+		String style = opt("style", "default.render.xml");
+		System.out.println("Renderer       : " + (openGl
+				? "opengl (v2, OsmAndCore through eyepiece)" : "legacy (v1, native library)"));
+		System.out.println("Maps           : " + mapsDir.getAbsolutePath());
+		System.out.println("Output         : " + outputDir.getAbsolutePath());
+		System.out.println("Reference cache: " + referenceCacheDir.getAbsolutePath()
+				+ " (" + countCachedReferences() + " tiles kept from the previous runs)");
+		System.out.println("Style          : " + style);
+		if (openGl) {
+			initOpenGlRenderer(style);
+		} else {
+			initLegacyRenderer(style);
+		}
 		if (loadAllMaps) {
 			initAllMaps();
 		} else {
@@ -759,7 +817,28 @@ public class CoastlineRenderingTester {
 			}
 		}
 		Collections.sort(maps);
+		if (openGl) {
+			// core keeps its own index cache and opens the maps of -obfsPath by itself
+			for (File f : maps) {
+				initializedMaps.add(f.getName());
+			}
+		} else {
+			initLegacyMaps(maps);
+		}
+		System.out.println("Initialized " + maps.size() + " maps from " + mapsDir.getAbsolutePath());
+		if (!skipped.isEmpty()) {
+			Collections.sort(skipped);
+			System.out.println("Skipped " + skipped.size() + " overlay maps (-exclude): "
+					+ String.join(", ", skipped));
+		}
+	}
 
+	/**
+	 * Hands the maps to the native library. The obf indexes are read through {@code indexes.cache},
+	 * otherwise the native library reports "File not initialized from cache" and re-reads the index
+	 * of every single map on every run.
+	 */
+	private void initLegacyMaps(List<File> maps) throws IOException {
 		// The cache lives in the folder the job runs in (the Jenkins workspace), so that it is wiped
 		// together with it and is never written into the shared maps folder. Building it costs about
 		// 20 ms per map; a run that finds the cache already there skips that entirely.
@@ -818,12 +897,6 @@ public class CoastlineRenderingTester {
 			renderer.initMapFile(f.getAbsolutePath(), true);
 			initializedMaps.add(f.getName());
 		}
-		System.out.println("Initialized " + maps.size() + " maps from " + mapsDir.getAbsolutePath());
-		if (!skipped.isEmpty()) {
-			Collections.sort(skipped);
-			System.out.println("Skipped " + skipped.size() + " overlay maps (-exclude): "
-					+ String.join(", ", skipped));
-		}
 	}
 
 	/** Initializes one map, downloading it into the maps folder when it is missing. */
@@ -840,7 +913,9 @@ public class CoastlineRenderingTester {
 			return false;
 		}
 		System.out.println("Init map " + f.getAbsolutePath());
-		renderer.initMapFile(f.getAbsolutePath(), true);
+		if (!openGl) {
+			renderer.initMapFile(f.getAbsolutePath(), true);
+		}
 		initializedMaps.add(name);
 		return true;
 	}
@@ -848,7 +923,9 @@ public class CoastlineRenderingTester {
 	private void closeAllMaps() {
 		for (String name : new ArrayList<>(initializedMaps)) {
 			File f = new File(mapsDir, name);
-			renderer.closeMapFile(f.getAbsolutePath());
+			if (!openGl) {
+				renderer.closeMapFile(f.getAbsolutePath());
+			}
 			initializedMaps.remove(name);
 		}
 	}
@@ -1152,6 +1229,16 @@ public class CoastlineRenderingTester {
 	 * 6/4/62 and 6/58/19 come out as land through it and as water through this one.
 	 */
 	private BufferedImage render(int zoom, int x, int y) throws IOException {
+		if (openGl) {
+			// eyepiece renders from the tile centre with the window sized to one tile, so the tile
+			// bounds are its own business - all it needs is the current set of maps
+			List<File> maps = new ArrayList<>();
+			for (String name : initializedMaps) {
+				maps.add(new File(mapsDir, name));
+			}
+			eyePiece.setMaps(maps);
+			return eyePiece.render(zoom, x, y);
+		}
 		int shift = 31 - zoom;
 		int left = x << shift;
 		int top = y << shift;
@@ -1580,8 +1667,9 @@ public class CoastlineRenderingTester {
 		for (GroupTotals g : result.groups) {
 			System.out.printf("%-58s %7d %7d%n", g.group, g.tiles, g.failedTiles);
 		}
-		System.out.printf("%d tiles compared, %d failed, %d maps loaded, %.1f s%n", result.comparedTiles,
-				result.failedTiles, result.loadedMaps, result.durationMs / 1000.0);
+		System.out.printf("%d tiles compared, %d failed, %d maps loaded, %s renderer, %.1f s%n",
+				result.comparedTiles, result.failedTiles, result.loadedMaps, result.renderer,
+				result.durationMs / 1000.0);
 		System.out.println(result.failedTiles > 0
 				? "COASTLINE PROBLEMS REPRODUCED - exit code 2"
 				: "No coastline problems found - exit code 0");
@@ -1635,9 +1723,10 @@ public class CoastlineRenderingTester {
 		sb.append("<link rel=\"stylesheet\" href=\"" + REPORT_CSS_FILE + "\">\n</head><body>\n");
 		sb.append("<header><h1>Coastline rendering &mdash; epic 3291</h1>");
 		sb.append(String.format("<p class=\"sum\"><b class=\"%s\">%d failed</b> &middot; %d tiles compared "
-						+ "&middot; %d maps &middot; style %s &middot; %.1f s &middot; %s</p>",
+						+ "&middot; %d maps &middot; %s renderer &middot; style %s &middot; %.1f s &middot; %s</p>",
 				result.failedTiles > 0 ? "bad" : "good", result.failedTiles, result.comparedTiles,
-				result.loadedMaps, esc(result.style), result.durationMs / 1000.0, new java.util.Date()));
+				result.loadedMaps, esc(result.renderer), esc(result.style),
+				result.durationMs / 1000.0, new java.util.Date()));
 		if (result.groups.size() > 1) {
 			StringBuilder g = new StringBuilder();
 			for (GroupTotals t : result.groups) {
@@ -1819,6 +1908,54 @@ public class CoastlineRenderingTester {
 			f = f.getParentFile();
 		}
 		return new File(System.getProperty("user.dir"));
+	}
+
+	/**
+	 * Explicit {@code -eyepiece=}, else the binary of a local repository checkout, else whatever is
+	 * called {@code eyepiece} on the PATH - which is how the build server gets it.
+	 */
+	private File findEyePiece() {
+		String explicit = opt("eyepiece", null);
+		if (explicit != null) {
+			File f = new File(explicit);
+			if (!f.isFile()) {
+				throw new IllegalStateException("-eyepiece=" + explicit + " does not exist");
+			}
+			return f;
+		}
+		String name = System.getProperty("os.name").toLowerCase().contains("win")
+				? "eyepiece.exe" : "eyepiece";
+		List<File> found = new ArrayList<>();
+		collect(new File(repoRoot(), "binaries"), name, found, 4);
+		if (!found.isEmpty()) {
+			return found.get(0);
+		}
+		for (String dir : System.getenv().getOrDefault("PATH", "").split(File.pathSeparator)) {
+			File f = new File(dir, name);
+			if (f.isFile() && f.canExecute()) {
+				return f;
+			}
+		}
+		throw new IllegalStateException("eyepiece is not found, pass -eyepiece=<path to the binary>."
+				+ " It is built from core/tools (OsmAndCore) and published by the build server as"
+				+ " part of the core binaries");
+	}
+
+	/**
+	 * Explicit {@code -stylesPath=}, else the styles of a local repository checkout. Null means "use
+	 * the styles built into OsmAndCore", which is what the build server does.
+	 */
+	private File findStyles() {
+		String explicit = opt("stylesPath", null);
+		if (explicit != null) {
+			File f = new File(explicit);
+			if (!f.isDirectory()) {
+				throw new IllegalStateException("-stylesPath=" + explicit + " is not a folder");
+			}
+			return f;
+		}
+		File f = new File(repoRoot(), "resources/rendering_styles");
+		return f.isDirectory() ? f : null;
 	}
 
 	/**

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/EyePieceTileRenderer.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/EyePieceTileRenderer.java
@@ -1,0 +1,244 @@
+package net.osmand.render;
+
+import java.awt.image.BufferedImage;
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.imageio.ImageIO;
+
+/**
+ * Renders map tiles with the <b>OpenGL (v2 / OsmAndCore)</b> engine, by driving the {@code eyepiece}
+ * tool of core as a co-process - the counterpart of {@code NativeJavaRendering}, which is the legacy
+ * (v1) engine.
+ *
+ * <p>eyepiece is started <i>once</i> and is fed the tiles one by one through its batch tile mode
+ * ({@code -tiles=- -tilesOutputDir=...}): it reads {@code z/x/y} lines from stdin, renders one image
+ * per tile and answers with a {@code TILE z/x/y <file>} line. That matters - a process per tile costs
+ * 2 s with two maps and 9 s with 182 of them before it draws anything, all of it obf index scanning
+ * and OpenGL setup, which would make a run of thousands of tiles impossible.
+ *
+ * <p>A tile is rendered from the centre of the tile in 31 bit coordinates with the window sized to
+ * exactly one tile, which is what makes the result comparable with a raster tile server. Verified
+ * pixel by pixel: two horizontally adjacent tiles rendered this way are identical to the two halves
+ * of a single 512x256 render centred on their common edge.
+ *
+ * <p>The set of maps is fixed when the process starts, so {@link #setMaps} only records it and the
+ * process is restarted before the next tile. The maps are handed over as a folder of symbolic links
+ * ({@code -obfsPath=}), because a case that closes every map and a full server run with a thousand
+ * of them are the same code path this way, and the command line stays short.
+ */
+class EyePieceTileRenderer implements Closeable {
+
+	/** Answer of eyepiece for one tile - see the tiles mode of EyePiece.cpp. */
+	private static final String TILE_PREFIX = "TILE ";
+
+	/** Output lines kept for the error message when the process dies. */
+	private static final int KEPT_LOG_LINES = 40;
+
+	private final File binary;
+	private final File stylesPath;
+	private final String styleName;
+	private final int tileSize;
+	private final File mapsLinkDir;
+	private final File tilesDir;
+	private final boolean verbose;
+
+	private final Set<File> maps = new LinkedHashSet<>();
+	private final Deque<String> lastLines = new ArrayDeque<>();
+
+	private Process process;
+	private Writer toProcess;
+	private BufferedReader fromProcess;
+	/** The maps changed (or nothing was started yet), so the process has to be restarted. */
+	private boolean restartNeeded = true;
+	private int startCount;
+
+	EyePieceTileRenderer(File binary, File stylesPath, String styleName, int tileSize, File workDir,
+			boolean verbose) {
+		this.binary = binary;
+		this.stylesPath = stylesPath;
+		this.styleName = styleName;
+		this.tileSize = tileSize;
+		this.mapsLinkDir = new File(workDir, "opengl-maps");
+		this.tilesDir = new File(workDir, "opengl-tiles");
+		this.verbose = verbose;
+	}
+
+	/** The maps eyepiece must see. Takes effect on the next tile, by restarting the process. */
+	void setMaps(Collection<File> newMaps) {
+		Set<File> wanted = new LinkedHashSet<>(newMaps);
+		if (!wanted.equals(maps)) {
+			maps.clear();
+			maps.addAll(wanted);
+			restartNeeded = true;
+		}
+	}
+
+	/** Renders one tile of the {@code z/x/y} scheme, 256x256 by default. */
+	BufferedImage render(int zoom, int x, int y) throws IOException {
+		ensureStarted();
+		String tile = zoom + "/" + x + "/" + y;
+		toProcess.write(tile + "\n");
+		toProcess.flush();
+		String answer = readAnswer(tile);
+		File png = new File(answer);
+		if (!png.isFile()) {
+			throw new IOException("eyepiece did not write " + png.getAbsolutePath() + " for " + tile);
+		}
+		try {
+			BufferedImage img = ImageIO.read(png);
+			if (img == null) {
+				throw new IOException("eyepiece wrote an unreadable image for " + tile);
+			}
+			return img;
+		} finally {
+			// the tiles worth keeping are written by the tester itself, into the report
+			png.delete();
+		}
+	}
+
+	/**
+	 * Reads the output of eyepiece until the answer for {@code tile}. Everything the renderer logs
+	 * goes to the same stream, hence the {@value #TILE_PREFIX} prefix; the stream must be consumed
+	 * anyway, or the process blocks on a full pipe.
+	 */
+	private String readAnswer(String tile) throws IOException {
+		String expected = TILE_PREFIX + tile + " ";
+		for (;;) {
+			String line = fromProcess.readLine();
+			if (line == null) {
+				int code = -1;
+				try {
+					code = process.waitFor();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				stop();
+				throw new IOException("eyepiece died (exit code " + code + ") on tile " + tile
+						+ ", last output:\n" + String.join("\n", lastLines));
+			}
+			keepLine(line);
+			if (verbose) {
+				System.out.println("  [eyepiece] " + line);
+			}
+			if (line.startsWith(expected)) {
+				String rest = line.substring(expected.length()).trim();
+				if (rest.startsWith("ERROR")) {
+					throw new IOException("eyepiece could not render " + tile + ": " + rest);
+				}
+				return rest;
+			}
+			if (line.startsWith(TILE_PREFIX)) {
+				// answers are in order, so this is an answer for a tile nobody is waiting for
+				throw new IOException("eyepiece answered '" + line + "' while " + tile + " was asked");
+			}
+		}
+	}
+
+	private void keepLine(String line) {
+		lastLines.addLast(line);
+		while (lastLines.size() > KEPT_LOG_LINES) {
+			lastLines.removeFirst();
+		}
+	}
+
+	private void ensureStarted() throws IOException {
+		if (process != null && process.isAlive() && !restartNeeded) {
+			return;
+		}
+		stop();
+		linkMaps();
+		tilesDir.mkdirs();
+		List<String> cmd = new ArrayList<>();
+		cmd.add(binary.getAbsolutePath());
+		cmd.add("-obfsPath=" + mapsLinkDir.getAbsolutePath());
+		if (stylesPath != null) {
+			cmd.add("-stylesPath=" + stylesPath.getAbsolutePath());
+		}
+		cmd.add("-styleName=" + styleName);
+		cmd.add("-tiles=-");
+		cmd.add("-tilesOutputDir=" + tilesDir.getAbsolutePath());
+		cmd.add("-tileSize=" + tileSize);
+		ProcessBuilder pb = new ProcessBuilder(cmd);
+		pb.redirectErrorStream(true);
+		// the shared libraries of core and Qt normally sit next to the binary
+		String libs = binary.getAbsoluteFile().getParent();
+		pb.environment().merge("DYLD_LIBRARY_PATH", libs, (old, add) -> add + File.pathSeparator + old);
+		pb.environment().merge("LD_LIBRARY_PATH", libs, (old, add) -> add + File.pathSeparator + old);
+		process = pb.start();
+		toProcess = new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8);
+		fromProcess = new BufferedReader(new InputStreamReader(process.getInputStream(),
+				StandardCharsets.UTF_8));
+		lastLines.clear();
+		restartNeeded = false;
+		startCount++;
+		System.out.println("Started eyepiece #" + startCount + " with " + maps.size() + " map(s)");
+	}
+
+	/**
+	 * Rebuilds the folder of symbolic links that is handed to eyepiece as {@code -obfsPath}. A copy
+	 * would cost gigabytes and the maps folder itself can not be used - it holds the overlays and
+	 * the road/srtm/wiki files the tester excludes on purpose.
+	 */
+	private void linkMaps() throws IOException {
+		mapsLinkDir.mkdirs();
+		File[] existing = mapsLinkDir.listFiles();
+		if (existing != null) {
+			for (File f : existing) {
+				Files.deleteIfExists(f.toPath());
+			}
+		}
+		for (File map : maps) {
+			Path link = new File(mapsLinkDir, map.getName()).toPath();
+			try {
+				Files.createSymbolicLink(link, map.getAbsoluteFile().toPath());
+			} catch (IOException | UnsupportedOperationException e) {
+				throw new IOException("Can't link " + map.getAbsolutePath() + " into "
+						+ mapsLinkDir.getAbsolutePath() + ": " + e.getMessage(), e);
+			}
+		}
+	}
+
+	private void stop() {
+		if (process == null) {
+			return;
+		}
+		try {
+			toProcess.close();
+		} catch (IOException e) {
+			// the process is going away anyway
+		}
+		try {
+			// closed stdin ends the tile loop, and eyepiece releases the OpenGL context on its own
+			if (!process.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)) {
+				process.destroyForcibly();
+			}
+		} catch (InterruptedException e) {
+			process.destroyForcibly();
+			Thread.currentThread().interrupt();
+		}
+		process = null;
+		toProcess = null;
+		fromProcess = null;
+	}
+
+	@Override
+	public void close() {
+		stop();
+	}
+}


### PR DESCRIPTION
The coastline rendering test has only ever drawn with the legacy native renderer (v1), while the
apps draw with OsmAndCore (v2), so the test said nothing about the engine users actually see.

`-renderer=opengl` runs the very same cases, water masks, report and exit codes through OsmAndCore,
which makes the two runs directly comparable. The renderer is recorded in `summary.json` and in the
report header, so a report can never be mistaken for the other engine's.

```bash
OsmAndMapCreator/utilities.sh test-coastline-rendering -renderer=opengl -maps.dir=/home/tileserver/maps
```

### How

The v2 tiles come from the `eyepiece` tool of core, driven as a co-process through its batch tile
mode (`-tiles=-`, tiles as `z/x/y` lines on stdin, one image and one `TILE z/x/y <file>` answer per
tile). **Needs osmandapp/OsmAnd-core#1100**, i.e. an eyepiece that has that mode — the currently
published `eyepiece_standalone` does not yet (`strings eyepiece | grep tilesOutputDir` says whether
a binary has it).

A process per tile was not an option: it costs 2 s of start up with two maps and 8.6 s with 182 of
them before anything is drawn. In this mode no legacy library, no fonts folder and no
`indexes.cache` are needed — core does all of that itself, `-native=` is ignored. The set of maps is
fixed when the eyepiece process starts, so the maps are handed over as a folder of symlinks and a
changed set restarts the process (`Started eyepiece #N` in the log).

New options, all only for `-renderer=opengl`: `-eyepiece=` (autodetected in `binaries/` of a
checkout and on the PATH), `-stylesPath=` (default: the styles built into core), `-eyepieceLog=`.
`-tileSize=` was parsed but unused before and is now honoured by this renderer.

### Measured, 276 fixed case tiles

| case | legacy | opengl |
|---|---|---|
| #25119 Goa flooding | 4 failed, 7.81% extra water | **0 failed** |
| #24376 grey squares in the ocean | 4 failed | 1 failed |
| #25618 St. Lawrence | 23 failed, 97.03% | 23 failed, the same tiles |
| #23353 San Francisco | 0 failed | **1 failed**, 12.40% extra water |
| #18187 seamarks inland (x2) | 3 + 3 failed | 3 + 3 failed, identical |
| total | 37 failed, 12 s | 31 failed, 193 s |

The two `seamarksInland` cases failing identically is the sanity check — they are a map data
problem and have nothing to do with the renderer. v2 is about **20x slower per tile**, 0.7 s against
25 ms, so a 10 000 tile random run is hours of rendering; on the build server keep the OpenGL run to
the fixed cases or a small `-randomTilesK`.

### Jenkins (`Web_Ocean_Tiles_Test`)

Not part of this PR, but the job change this is meant for — a `RENDERER` choice parameter and:

```bash
EXTRA=""
if [ "$RENDERER" = "opengl" ]; then
  # built with EGL (EGL_PLATFORM_DEVICE_EXT), so it renders headless - no X server, no xvfb-run
  curl -sS -z eyepiece -o eyepiece https://builder.osmand.net/binaries/amd64-linux-clang/eyepiece_standalone
  chmod +x eyepiece
  EXTRA="-renderer=opengl -eyepiece=$PWD/eyepiece -randomTilesK=${RANDOM_TILES_K:-1}"
fi
OsmAndMapCreator/utilities.sh test-coastline-rendering -maps.dir=/home/tileserver/maps \
  -out=$WORKSPACE/report $EXTRA
```

Also adds the eyepiece usage text for the new arguments in `cpp-tools/map-rasterizer/main.cpp`, and
documents the mode in the `coastline-rendering-test` skill.

Tested on macOS: all 276 fixed case tiles in both modes (numbers above), `-load=all` with 137 maps,
and the `seamarksInland` cases, which open and close maps per tile.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. The coastline test should be able to render its tiles with the OpenGL engine; add a parameter
   for it, `bird`/`eyepiece` are already built locally, the tools checkout is busy with another
   session. What do we do, let's do it.
2. Answers to three questions: edit core in place, keep tile.osmand.net (carto) as the reference
   rather than adding a v1-vs-v2 diff mode, hand over only the Jenkins command line and do not
   touch the job.
3. Open the pull requests.

Decided by the agent, not requested explicitly:
- Driving eyepiece as a co-process in batch tile mode instead of spawning it per tile (measured
  start up cost), and the corresponding core change (osmandapp/OsmAnd-core#1100).
- Handing the map set over as a folder of symlinks and restarting eyepiece when the set changes,
  which is what makes `-load=case` and the `seamarksInland` cases work unchanged.
- Splitting `initRenderer()` into a v1 and a v2 setup, and `initAllMaps()` into the shared part and
  the legacy `indexes.cache` part; recording the renderer in `summary.json` and in the report.
- The option names `-eyepiece`, `-stylesPath`, `-eyepieceLog`, and honouring the previously unused
  `-tileSize`.
- Running both engines over the whole fixed case set to get the comparison table above, and writing
  the Jenkins snippet and the skill section.
