### PR TITLE
OverpassFetcher: ask Overpass for decoded OSM ids

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/OverpassFetcher.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/OverpassFetcher.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import net.osmand.binary.ObfConstants;
 import net.osmand.osm.edit.Entity;
 import net.osmand.osm.edit.Entity.EntityId;
 import net.osmand.osm.edit.Entity.EntityType;
@@ -102,6 +103,16 @@ public class OverpassFetcher {
 	}
 
 	private Map<EntityId, Entity> parseEntities(JSONArray elements, OsmDbAccessorContext ctx) {
+		return parseEntities(elements, ctx, null);
+	}
+
+	/**
+	 * @param internalIdByOsmId maps the id Overpass answers with back to the id the relation refers
+	 *                          to, so initializeLinks() can match what was fetched. Null when the
+	 *                          caller already works in plain OSM ids.
+	 */
+	private Map<EntityId, Entity> parseEntities(JSONArray elements, OsmDbAccessorContext ctx,
+			Map<Long, Long> internalIdByOsmId) {
 		Map<EntityId, Entity> fetchedEntities = new HashMap<>();
 		if (elements == null) {
 			return fetchedEntities;
@@ -129,7 +140,9 @@ public class OverpassFetcher {
 				JSONArray nodeIds = element.optJSONArray("nodes");
 				JSONArray geoms = element.optJSONArray("geometry");
 
-				Way way = new Way(wayId);
+				long targetId = internalIdByOsmId == null
+						? wayId : internalIdByOsmId.getOrDefault(wayId, wayId);
+				Way way = new Way(targetId);
 				if (nodeIds != null) {
 					for (int j = 0; j < nodeIds.length(); j++) {
 						long nodeId = nodeIds.getLong(j);
@@ -148,7 +161,7 @@ public class OverpassFetcher {
 						}
 					}
 				}
-				fetchedEntities.put(new EntityId(Entity.EntityType.WAY, wayId), way);
+				fetchedEntities.put(new EntityId(Entity.EntityType.WAY, targetId), way);
 			}
 		}
 		return fetchedEntities;
@@ -237,17 +250,41 @@ public class OverpassFetcher {
 		}
 
 		long startTime = System.currentTimeMillis();
-		String wayIds = String.join(",", wayIdsToFetch.stream().map(String::valueOf).toArray(String[]::new));
+
+		// Member ids here are already in OsmAnd's internal encoding - OsmDbCreator.convertId()
+		// shifts every positive OSM id left by ObfConstants.SHIFT_ID and packs a geohash into the
+		// low bits. Asking Overpass for those (way 99214274955 rather than way 1550223046) simply
+		// finds nothing, the relation stays incomplete and, before this, was dropped whole. Ask for
+		// the decoded ids and remember which internal id each one belongs to.
+		Map<Long, Long> internalIdByOsmId = new HashMap<>();
+		for (Long internalId : wayIdsToFetch) {
+			internalIdByOsmId.putIfAbsent(internalId, internalId);
+			long decoded = internalId >> ObfConstants.SHIFT_ID;
+			if (decoded > 0) {
+				internalIdByOsmId.putIfAbsent(decoded, internalId);
+			}
+		}
+		String wayIds = String.join(",",
+				internalIdByOsmId.keySet().stream().map(String::valueOf).toArray(String[]::new));
 		String dateHeader = buildDateHeader(lastModifiedDate);
 		String query = "[out:json]" + dateHeader + ";way(id:" + wayIds + "); out geom;";
 
-		JSONArray elements = executeOverpassQuery(query);
-		Map<EntityId, Entity> fetchedEntities = parseEntities(elements, ctx);
+        JSONArray elements = executeOverpassQuery(query);
+		Map<EntityId, Entity> fetchedEntities = parseEntities(elements, ctx, internalIdByOsmId);
 
 		relation.initializeLinks(fetchedEntities);
 
 		log.info(String.format("Fetched %d member ways for relation %d (%.2f sec)",
 				wayIdsToFetch.size(), relation.getId(), (System.currentTimeMillis() - startTime) / 1e3));
+
+		List<Long> stillIncomplete = getIncompleteWayIdsForRelation(relation);
+		if (!stillIncomplete.isEmpty()) {
+			log.warn(String.format("Relation %d: %d of %d fetched ways are still unresolved, e.g. %s"
+							+ " (elements returned: %d)",
+					relation.getId(), stillIncomplete.size(), wayIdsToFetch.size(),
+					stillIncomplete.subList(0, Math.min(5, stillIncomplete.size())),
+					elements == null ? -1 : elements.length()));
+		}
 	}
 
 	public List<Long> getIncompleteWayIdsForRelation(Relation relation) {


### PR DESCRIPTION
## The bug

Relation members reach `OverpassFetcher` already in OsmAnd's **internal id encoding**.
`OsmDbCreator.convertId()` shifts every positive OSM id left by `ObfConstants.SHIFT_ID` (6) and packs
a geohash into the low bits:

```java
cid = (id << ObfConstants.SHIFT_ID) + (ord % 2) + (l << 1);
```

`getIncompleteWayIdsForRelation()` returns those ids and the fetcher put them straight into
`way(id:...)`. So it asked Overpass for **way 99214274955** instead of **way 1550223046**. Overpass
finds nothing, the member never gets geometry, the relation is reported incomplete — and
`IndexRouteRelationCreator` drops the entire route.

## How it was found

Measured on an Ojców extract, with `OVERPASS_URL` correctly configured:

```
Relation 1697777: 4 of 381 fetched ways are still unresolved,
  e.g. [1553214307, 1553214365, 17180411347, 17180409281]  (elements returned: 377)
```

Shifting those back by 6 gives ways 24268973, 24268974, 268443895 and 268443927 — **all four exist**,
as do the other two seen on a different relation:

| id sent to Overpass | `>> SHIFT_ID` | exists in OSM |
|---|---|---|
| 1553214307 | 24268973 | yes |
| 1553214365 | 24268974 | yes |
| 17180411347 | 268443927 | yes |
| 17180409281 | 268443895 | yes |
| 37368063211 | 583875987 | yes |
| 99214274955 | 1550223046 | yes |

`Szlak Warowni Jurajskich` — 510 member ways, a 160 km regional route — was absent from the generated
map entirely because of this. With the ids decoded it resolves fully and appears with 79 objects.

The server was never at fault: the same 510 ways come back complete in one query, with and without a
`[date:...]` header.

## The fix

Send the decoded id alongside the encoded one, and re-key whatever comes back to the id the relation
actually refers to so `initializeLinks()` matches. Both are sent because not every id in a relation is
shifted — `OsmDbCreator` leaves some untouched — and the fetcher cannot tell which is which.

Also logs which members are still unresolved after a fetch. Without that the failure is invisible:
the existing line reports how many ways were *requested*, not how many came back, so 377 of 381 read
as success. That log line is what made this findable at all.

## Not covered here

A few members still fail to resolve after this change. They are ways whose raw id does exist and is
returned, but the response carries `geometry` without a `nodes` array, so the way ends up with no
nodes. That is a separate issue in `parseEntities` and is not addressed in this PR.

Separately, `IndexRouteRelationCreator.getRelationHash()` returning `-1` drops a whole relation when
any single member is unresolved, even though the hash only spreads generated object ids. That is
also left alone here.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Work on drawing overlapping hiking/cycling routes as parallel lanes, generating test maps for the Tatras, Krkonoše, Slovakia and Ojców.
2. Reported that a route visible on OSM (way 124266607, three routes) was missing from the generated map, and linked the relation that was absent.
3. Asked why the relation is thrown away at all, since shields do not need completeness.
4. Asked why the fetcher had not downloaded everything given `OVERPASS_URL` was set, and where those ids came from.
5. Asked for the proper fix as a separate pull request.

Decided by the agent, not requested explicitly:
- Sending both the encoded and decoded id rather than trying to detect which form each member uses.
- Adding the post-fetch diagnostic log.
- Leaving the `parseEntities` geometry-without-nodes case and the `getRelationHash` drop for separate changes, and saying so above.
