### PR TITLE
Coastline test: check that eyepiece has the batch tile mode before the run

### DIFF
--- a/.claude/skills/coastline-rendering-test/SKILL.md
+++ b/.claude/skills/coastline-rendering-test/SKILL.md
@@ -55,11 +55,14 @@ It drives the `eyepiece` tool of core as a co-process through its batch tile mod
 (`-tiles=- -tilesOutputDir=...`, tiles as `z/x/y` lines on stdin, one `TILE z/x/y <file>` answer
 per tile). Things worth knowing:
 
-- **The binary needs the batch tile mode**, i.e. core with `-tiles=`. Check with
-  `strings eyepiece | grep tilesOutputDir` before blaming the tester; the published
+- **The binary needs the batch tile mode**, i.e. core with `-tiles=` (OsmAnd-core#1100). The tester
+  checks it at start up and stops with an explanation (`-eyepieceCheck=false` skips the check);
+  `strings eyepiece | grep tilesOutputDir` answers the same question by hand. The published
   `https://builder.osmand.net/binaries/amd64-linux-clang/eyepiece_standalone` is the build server's
   copy and is the one to use on Jenkins (it is linked with EGL - `EGL_PLATFORM_DEVICE_EXT` - so it
-  renders headless, no X server and no `xvfb-run` needed).
+  renders headless, no X server and no `xvfb-run` needed), **but it is rebuilt by
+  `OsmAndCoreAndTools-linux-clang-64bit` and lags a core merge until that job runs** - which is
+  exactly how the first opengl run of the Jenkins job failed.
 - `-eyepiece=` is autodetected from `binaries/` of a repository checkout and from the PATH.
   `-stylesPath=` defaults to the styles built into core, `-eyepieceLog=true` echoes everything
   eyepiece prints.

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
@@ -115,7 +115,8 @@ import net.osmand.util.MapsCollection;
  * <li>{@code eyepiece}, {@code stylesPath} - only for {@code -renderer=opengl}: path to the
  * eyepiece binary (autodetected in {@code binaries} of a repository checkout and on the PATH) and
  * the folder with the {@code *.render.xml} styles (by default the styles built into OsmAndCore).
- * {@code -eyepieceLog=true} echoes everything eyepiece prints;</li>
+ * {@code -eyepieceLog=true} echoes everything eyepiece prints, {@code -eyepieceCheck=false} skips
+ * the check that the binary has the batch tile mode at all;</li>
  * <li>{@code native} - path to {@code libosmand.dylib/so/dll}; by default the library bundled into
  * OsmAndMapCreator is used, a local repository checkout picks it up from {@code core-legacy}.
  * Ignored by {@code -renderer=opengl}, which needs no legacy library at all;</li>
@@ -740,7 +741,7 @@ public class CoastlineRenderingTester {
 	 * itself. The style is resolved by name ({@code default.render.xml} is {@code default}), from
 	 * {@code -stylesPath} when it is given and from the styles built into core otherwise.
 	 */
-	private void initOpenGlRenderer(String style) {
+	private void initOpenGlRenderer(String style) throws IOException {
 		File binary = findEyePiece();
 		File stylesPath = findStyles();
 		String styleName = style.endsWith(".render.xml")
@@ -750,6 +751,9 @@ public class CoastlineRenderingTester {
 				? "built into OsmAndCore" : stylesPath.getAbsolutePath()));
 		eyePiece = new EyePieceTileRenderer(binary, stylesPath, styleName, tileSize, outputDir,
 				Boolean.parseBoolean(opt("eyepieceLog", "false")));
+		if (Boolean.parseBoolean(opt("eyepieceCheck", "true"))) {
+			eyePiece.checkBatchTileMode();
+		}
 	}
 
 	private void initRenderer() throws Exception {

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/EyePieceTileRenderer.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/EyePieceTileRenderer.java
@@ -18,6 +18,7 @@ import java.util.Deque;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.imageio.ImageIO;
 
@@ -49,6 +50,12 @@ class EyePieceTileRenderer implements Closeable {
 
 	/** Output lines kept for the error message when the process dies. */
 	private static final int KEPT_LOG_LINES = 40;
+
+	/** How long {@link #checkBatchTileMode} waits for eyepiece to print its usage and exit. */
+	private static final int PROBE_TIMEOUT_SECONDS = 60;
+
+	/** How long a process gets to leave on its own once its stdin is closed. */
+	private static final int STOP_TIMEOUT_SECONDS = 30;
 
 	private final File binary;
 	private final File stylesPath;
@@ -174,13 +181,7 @@ class EyePieceTileRenderer implements Closeable {
 		cmd.add("-tiles=-");
 		cmd.add("-tilesOutputDir=" + tilesDir.getAbsolutePath());
 		cmd.add("-tileSize=" + tileSize);
-		ProcessBuilder pb = new ProcessBuilder(cmd);
-		pb.redirectErrorStream(true);
-		// the shared libraries of core and Qt normally sit next to the binary
-		String libs = binary.getAbsoluteFile().getParent();
-		pb.environment().merge("DYLD_LIBRARY_PATH", libs, (old, add) -> add + File.pathSeparator + old);
-		pb.environment().merge("LD_LIBRARY_PATH", libs, (old, add) -> add + File.pathSeparator + old);
-		process = pb.start();
+		process = start(cmd);
 		toProcess = new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8);
 		fromProcess = new BufferedReader(new InputStreamReader(process.getInputStream(),
 				StandardCharsets.UTF_8));
@@ -188,6 +189,56 @@ class EyePieceTileRenderer implements Closeable {
 		restartNeeded = false;
 		startCount++;
 		System.out.println("Started eyepiece #" + startCount + " with " + maps.size() + " map(s)");
+	}
+
+	private Process start(List<String> cmd) throws IOException {
+		ProcessBuilder pb = new ProcessBuilder(cmd);
+		pb.redirectErrorStream(true);
+		// the shared libraries of core and Qt normally sit next to the binary
+		String libs = binary.getAbsoluteFile().getParent();
+		pb.environment().merge("DYLD_LIBRARY_PATH", libs, (old, add) -> add + File.pathSeparator + old);
+		pb.environment().merge("LD_LIBRARY_PATH", libs, (old, add) -> add + File.pathSeparator + old);
+		return pb.start();
+	}
+
+	/**
+	 * Fails when the binary has no batch tile mode, <i>before</i> the maps and the cases. An
+	 * eyepiece older than <a href="https://github.com/osmandapp/OsmAnd-core/pull/1100">core#1100</a>
+	 * answers "Unrecognized argument: '-tiles=-'" and dies on the first tile, with its whole usage
+	 * text as the error - which is what a build server picking up a stale published binary looks
+	 * like. Started without arguments eyepiece prints that usage and exits in 0.2 s, so the check
+	 * costs nothing.
+	 */
+	void checkBatchTileMode() throws IOException {
+		Process p = start(new ArrayList<>(List.of(binary.getAbsolutePath())));
+		StringBuilder usage = new StringBuilder();
+		try (BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream(),
+				StandardCharsets.UTF_8))) {
+			for (String line = r.readLine(); line != null; line = r.readLine()) {
+				usage.append(line).append('\n');
+			}
+		}
+		try {
+			if (!p.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+				p.destroyForcibly();
+				throw new IOException(binary.getAbsolutePath() + " does not answer, it printed:\n"
+						+ usage);
+			}
+		} catch (InterruptedException e) {
+			p.destroyForcibly();
+			Thread.currentThread().interrupt();
+			throw new IOException(e);
+		}
+		// "tilesOutputDir" appears in the usage text of the tile mode and nowhere else - "-tiles="
+		// alone would also match the "Unrecognized argument: '-tiles=-'" of an old binary
+		if (usage.indexOf("tilesOutputDir") < 0) {
+			throw new IOException(binary.getAbsolutePath() + " has no batch tile mode (-tiles),"
+					+ " it is older than https://github.com/osmandapp/OsmAnd-core/pull/1100."
+					+ " Take a newer build - the build server publishes one at"
+					+ " https://builder.osmand.net/binaries/amd64-linux-clang/eyepiece_standalone -"
+					+ " or build core from master. Pass -eyepieceCheck=false to skip this check."
+					+ " It printed:\n" + usage);
+		}
 	}
 
 	/**
@@ -225,7 +276,7 @@ class EyePieceTileRenderer implements Closeable {
 		}
 		try {
 			// closed stdin ends the tile loop, and eyepiece releases the OpenGL context on its own
-			if (!process.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)) {
+			if (!process.waitFor(STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
 				process.destroyForcibly();
 			}
 		} catch (InterruptedException e) {


### PR DESCRIPTION
Follow up to #1674. The first opengl run of `Web_Ocean_Tiles_Test`
([build 131](https://builder.osmand.net:8080/job/Web_Ocean_Tiles_Test/131/console)) ended like this:

```
Started eyepiece #1 with 1060 map(s)
java.io.IOException: eyepiece died (exit code 255) on tile 9/162/228, last output:
...
Unrecognized argument: '-tiles=-'
OsmAnd EyePiece tool is a console utility to rasterize part of map.
Arguments:
  -obfsPath=...
  [... 25 more lines of usage ...]
```

Nothing wrong with the run itself: the published
`builder.osmand.net/binaries/amd64-linux-clang/eyepiece_standalone` was built at 10:25 UTC and
osmandapp/OsmAnd-core#1100 was merged at 11:39 UTC, so the binary simply had no batch tile mode yet
(`strings eyepiece | grep tilesOutputDir` → nothing). It stays that way until
`OsmAndCoreAndTools-linux-clang-64bit` rebuilds it, so this will happen again on any machine with a
stale eyepiece, and the error says nothing about what to do.

eyepiece started without arguments prints its usage and exits in 0.2 s, so the tester now looks for
the tile mode there **before** the maps and the cases and stops with:

```
/path/to/eyepiece has no batch tile mode (-tiles), it is older than
https://github.com/osmandapp/OsmAnd-core/pull/1100. Take a newer build - the build server
publishes one at https://builder.osmand.net/binaries/amd64-linux-clang/eyepiece_standalone -
or build core from master. Pass -eyepieceCheck=false to skip this check. It printed: ...
```

Exit code 1, the documented "the tester could not run", instead of a failure on the first tile.
`-eyepieceCheck=false` skips it, for a binary whose usage text is older than its features.

Tested with the current eyepiece (unchanged: 54 tiles, 0 failed, exit 0) and against a stub that
prints the old usage (stops at start up, exit 1). The check matches `tilesOutputDir` rather than
`-tiles=`, because the latter also occurs in the `Unrecognized argument: '-tiles=-'` line an old
binary prints.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. The Jenkins job failed, link to the console log of build 131, fix it.

Decided by the agent, not requested explicitly:
- That the fix on this side is a start up capability check rather than a fallback to one eyepiece
  process per tile (which would work with the old binary but costs ~9 s per tile with 1060 maps,
  i.e. it would look like a hang).
- Probing by running eyepiece without arguments and reading its usage, the `-eyepieceCheck=false`
  escape hatch, and the wording of the message.
- The skill note about the published binary lagging a core merge.

Not addressed here: the job runs 9240 random tiles in opengl mode, which at ~1 s per tile is hours
of rendering - `-randomTilesK=1` or the fixed cases only is the practical setting for this engine.
