### PR TITLE
Coastline test: no map symbols, and survive a renderer that crashes on a tile

### DIFF
--- a/.claude/skills/coastline-rendering-test/SKILL.md
+++ b/.claude/skills/coastline-rendering-test/SKILL.md
@@ -72,11 +72,24 @@ per tile). Things worth knowing:
   eyepiece; the maps are handed over as a folder of symlinks in `<out>/opengl-maps`. Watch the
   `Started eyepiece #N` lines: with `-load=case` there is one per case, which is normal, but a
   restart with a thousand maps loaded costs the whole obf scan again.
-- **It is ~20x slower per tile than the legacy renderer** - measured 0.7 s/tile against 25 ms/tile
-  (276 fixed case tiles: 193 s against 12 s). A 10 000 tile run is hours of rendering, so on the
-  build server keep the OpenGL run to the fixed cases or a small `-randomTilesK`.
+- **Map symbols (labels and icons) are 94% of the time of a v2 tile** - measured 500 ms/tile with
+  them against 30 ms/tile without, which is the legacy renderer's own 25 ms. They say nothing about
+  a coastline, so `-symbols=false` is the default here; `-symbols=true` draws them. The 276 fixed
+  case tiles come out identical either way.
+- **A tile eyepiece crashes on does not end the run**: the process is restarted, the tile is tried
+  once more, and if it dies again it is counted as a renderer error, named in the report with the
+  message it died with, and the run goes on. Renderer errors make the exit code 2 the way a water
+  difference does - a renderer that aborts is a worse defect than a wrong coastline, it must not
+  end in a green build. 50 deaths in one run still give up.
+- The report is written **after every case**, not only every `flushEvery` tiles, so the fixed cases
+  can be read while the random tiles - the long part - are still running.
+- **Do not trust a single `isIdle()`** if you write your own eyepiece driver: right after a target
+  change the renderer can report idle before the resources of the new location are requested, and
+  the frame then holds nothing but the background. The tile mode waits for three idle polls in a
+  row; without that, scattered tiles come out blank now and then, and a blank tile reads as a
+  perfect coastline failure (100% missing water) in this test.
 
-Measured on the 276 fixed case tiles (September 2026): v2 fixes #25119 (Goa flooding: 4 failed
+Measured on the 276 fixed case tiles (September 2026), with and without symbols alike: v2 fixes #25119 (Goa flooding: 4 failed
 tiles against 0) and most of #24376, reproduces #25618 (St. Lawrence, 23 failed tiles) exactly like
 v1, and fails one San Francisco tile that v1 draws correctly. The two `seamarksInland` cases fail
 identically in both, which is the expected sanity check - they are a map data problem and have

--- a/cpp-tools/map-rasterizer/main.cpp
+++ b/cpp-tools/map-rasterizer/main.cpp
@@ -104,6 +104,7 @@ void printUsage(const std::string& warning /*= std::string()*/)
     tcout << xT("\t[-fov=16.5]") << std::endl;
     tcout << xT("\t[-referenceTileSize=256]") << std::endl;
     tcout << xT("\t[-displayDensityFactor=1.0]") << std::endl;
+    tcout << xT("\t[-noSymbols - no labels and icons, 94% faster per tile]") << std::endl;
     tcout << xT("\t[-locale=en]") << std::endl;
     tcout << xT("\t[-verbose]") << std::endl;
 #if defined(OSMAND_TARGET_OS_linux)

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/CoastlineRenderingTester.java
@@ -74,8 +74,9 @@ import net.osmand.util.MapsCollection;
  * # the same cases through the OpenGL engine of the apps instead of the legacy one
  * OsmAndMapCreator/utilities.sh test-coastline-rendering -renderer=opengl -maps.dir=/var/maps
  * </pre>
- * Exit code: <b>0</b> - everything matches the reference, <b>2</b> - problems were reproduced,
- * <b>1</b> - the tester could not run (native library could not be loaded, no maps, broken json).
+ * Exit code: <b>0</b> - everything matches the reference, <b>2</b> - problems were reproduced (a
+ * water difference, or a tile the renderer crashed on), <b>1</b> - the tester could not run (native
+ * library could not be loaded, no maps, broken json).
  *
  * <p>Every option can be given either as an argument ({@code -maps.dir=...}) or as a system
  * property ({@code -Dmaps.dir=...}):
@@ -117,6 +118,10 @@ import net.osmand.util.MapsCollection;
  * the folder with the {@code *.render.xml} styles (by default the styles built into OsmAndCore).
  * {@code -eyepieceLog=true} echoes everything eyepiece prints, {@code -eyepieceCheck=false} skips
  * the check that the binary has the batch tile mode at all;</li>
+ * <li>{@code symbols} - only for {@code -renderer=opengl}: {@code false} (default) renders the
+ * tiles without labels and icons. They are 94% of the time of a tile in the v2 engine (measured
+ * 500 ms against 30 ms per tile) and say nothing about a coastline, and the fixed cases come out
+ * identical either way; {@code -symbols=true} draws them;</li>
  * <li>{@code native} - path to {@code libosmand.dylib/so/dll}; by default the library bundled into
  * OsmAndMapCreator is used, a local repository checkout picks it up from {@code core-legacy}.
  * Ignored by {@code -renderer=opengl}, which needs no legacy library at all;</li>
@@ -311,6 +316,8 @@ public class CoastlineRenderingTester {
 		public int comparedTiles;
 		public int skippedTiles;
 		public int failedTiles;
+		/** Tiles the renderer could not draw at all - it crashed on them. */
+		public int renderErrors;
 		public double worstExtraWater;
 		public double worstMissingWater;
 		public double sumExtraWater;
@@ -332,6 +339,7 @@ public class CoastlineRenderingTester {
 		public String group;
 		public int tiles;
 		public int failedTiles;
+		public int renderErrors;
 	}
 
 	/** Result of a whole run, also written to {@code summary.json}. */
@@ -345,6 +353,9 @@ public class CoastlineRenderingTester {
 		public int tiles;
 		public int comparedTiles;
 		public int failedTiles;
+		public int renderErrors;
+		/** How many times the renderer died during the run, restarts included. */
+		public int rendererDeaths;
 		public List<CaseStats> cases = new ArrayList<>();
 		public List<GroupTotals> groups = new ArrayList<>();
 	}
@@ -432,7 +443,9 @@ public class CoastlineRenderingTester {
 		int code;
 		try {
 			RunResult res = new CoastlineRenderingTester(options).run();
-			code = res.failedTiles > 0 ? 2 : 0;
+			// a renderer that crashes on a tile is a worse problem than a wrong coastline, so it
+			// must not end in a green build either
+			code = res.failedTiles > 0 || res.renderErrors > 0 ? 2 : 0;
 		} catch (Throwable e) {
 			e.printStackTrace();
 			code = 1;
@@ -471,6 +484,10 @@ public class CoastlineRenderingTester {
 				} else {
 					runWaterCase(def);
 				}
+				// after every case, so that the fixed cases can be read while the random tiles -
+				// hours of them - are still running, and so that a killed job leaves behind the
+				// part of the report it did finish
+				writeReport();
 			}
 		} finally {
 			downloadPool.shutdownNow();
@@ -749,7 +766,10 @@ public class CoastlineRenderingTester {
 		System.out.println("eyepiece       : " + binary.getAbsolutePath());
 		System.out.println("Styles path    : " + (stylesPath == null
 				? "built into OsmAndCore" : stylesPath.getAbsolutePath()));
-		eyePiece = new EyePieceTileRenderer(binary, stylesPath, styleName, tileSize, outputDir,
+		boolean symbols = Boolean.parseBoolean(opt("symbols", "false"));
+		System.out.println("Map symbols    : " + (symbols
+				? "drawn" : "off, they are 94% of the time of a tile (-symbols=true draws them)"));
+		eyePiece = new EyePieceTileRenderer(binary, stylesPath, styleName, tileSize, symbols, outputDir,
 				Boolean.parseBoolean(opt("eyepieceLog", "false")));
 		if (Boolean.parseBoolean(opt("eyepieceCheck", "true"))) {
 			eyePiece.checkBatchTileMode();
@@ -1013,7 +1033,13 @@ public class CoastlineRenderingTester {
 			stats.skippedTiles++;
 			return;
 		}
-		BufferedImage rendered = render(zoom, x, y);
+		BufferedImage rendered;
+		try {
+			rendered = render(zoom, x, y);
+		} catch (EyePieceTileRenderer.TileRenderFailure e) {
+			renderError(def, stats, zoom, x, y, e);
+			return;
+		}
 		reference = scaleDown(reference, rendered.getWidth(), rendered.getHeight());
 		int w = rendered.getWidth(), h = rendered.getHeight();
 
@@ -1094,14 +1120,21 @@ public class CoastlineRenderingTester {
 			int[] t = it.next();
 			int zoom = t[0], x = t[1], y = t[2];
 			stats.tiles++;
-			closeAllMaps();
-			BufferedImage empty = render(zoom, x, y);
-			for (String map : def.maps) {
-				if (!initMap(map)) {
-					throw new IllegalStateException("Map " + map + " of " + def + " is not available");
+			BufferedImage empty, drawnImg;
+			try {
+				closeAllMaps();
+				empty = render(zoom, x, y);
+				for (String map : def.maps) {
+					if (!initMap(map)) {
+						throw new IllegalStateException("Map " + map + " of " + def + " is not available");
+					}
 				}
+				drawnImg = render(zoom, x, y);
+			} catch (EyePieceTileRenderer.TileRenderFailure e) {
+				closeAllMaps();
+				renderError(def, stats, zoom, x, y, e);
+				continue;
 			}
-			BufferedImage drawnImg = render(zoom, x, y);
 			closeAllMaps();
 
 			int background = dominantColor(empty);
@@ -1550,11 +1583,14 @@ public class CoastlineRenderingTester {
 		result.tiles = 0;
 		result.comparedTiles = 0;
 		result.failedTiles = 0;
+		result.renderErrors = 0;
+		result.rendererDeaths = eyePiece == null ? 0 : eyePiece.deaths();
 		Map<String, GroupTotals> byGroup = new LinkedHashMap<>();
 		for (CaseStats s : result.cases) {
 			result.tiles += s.tiles;
 			result.comparedTiles += s.comparedTiles;
 			result.failedTiles += s.failedTiles;
+			result.renderErrors += s.renderErrors;
 			GroupTotals g = byGroup.computeIfAbsent(s.group == null ? GROUP_FIXED : s.group, k -> {
 				GroupTotals t = new GroupTotals();
 				t.group = k;
@@ -1562,8 +1598,20 @@ public class CoastlineRenderingTester {
 			});
 			g.tiles += s.comparedTiles;
 			g.failedTiles += s.failedTiles;
+			g.renderErrors += s.renderErrors;
 		}
 		result.groups = new ArrayList<>(byGroup.values());
+	}
+
+	/** The report as it stands now - written after every case and every {@code flushEvery} tiles. */
+	private void writeReport() throws IOException {
+		recomputeTotals();
+		result.loadedMaps = initializedMaps.size();
+		result.durationMs = System.currentTimeMillis() - result.startedAt;
+		writeSummaryJson(result, true);
+		if (writeHtml) {
+			writeHtmlReport(result, true);
+		}
 	}
 
 	/**
@@ -1577,13 +1625,7 @@ public class CoastlineRenderingTester {
 		}
 		tilesSinceFlush = 0;
 		long now = System.currentTimeMillis();
-		recomputeTotals();
-		result.loadedMaps = initializedMaps.size();
-		result.durationMs = now - result.startedAt;
-		writeSummaryJson(result, true);
-		if (writeHtml) {
-			writeHtmlReport(result, true);
-		}
+		writeReport();
 		double perSec = result.comparedTiles * 1000.0 / Math.max(1, now - result.startedAt);
 		String eta = totalOfCase > 0 && perSec > 0
 				? String.format(", eta %s", duration((long) ((totalOfCase - stats.tiles) / perSec * 1000)))
@@ -1618,6 +1660,22 @@ public class CoastlineRenderingTester {
 			return false;
 		}
 		return "all".equalsIgnoreCase(saveImages) || !ok;
+	}
+
+	/**
+	 * A tile the renderer crashed on. It is a defect of the renderer rather than of the coastline,
+	 * but it is one the report has to carry - a run that quietly drops the tiles that killed the
+	 * renderer would look better the more broken the renderer is.
+	 */
+	private void renderError(CaseDef def, CaseStats stats, int zoom, int x, int y,
+			EyePieceTileRenderer.TileRenderFailure e) {
+		stats.renderErrors++;
+		TileResult res = new TileResult(def, zoom, x, y);
+		// worse than any water difference, so that these tiles come first in the report
+		res.severity = 2;
+		res.problems.add("Renderer error: " + e.getMessage());
+		keepForReport(res);
+		System.out.printf("  CRASHED %d/%d/%d - %s%n", zoom, x, y, e.getMessage());
 	}
 
 	private void keepForReport(TileResult res) {
@@ -1662,6 +1720,9 @@ public class CoastlineRenderingTester {
 				System.out.printf("%-58s worst tile %s, avg +H2O %s, avg -H2O %s%n", "",
 						s.worstTile, pct(s.avgExtraWater()), pct(s.avgMissingWater()));
 			}
+			if (s.renderErrors > 0) {
+				System.out.printf("%-58s %d tiles the renderer crashed on%n", "", s.renderErrors);
+			}
 			if (s.styledSaltPonds > 0.0001) {
 				System.out.printf("%-58s %s of the extra water is styled salt ponds (ignored)%n", "",
 						pct(s.styledSaltPonds / Math.max(1, s.comparedTiles)));
@@ -1669,14 +1730,22 @@ public class CoastlineRenderingTester {
 		}
 		System.out.println("-----------------------------------------------------------------------------------");
 		for (GroupTotals g : result.groups) {
-			System.out.printf("%-58s %7d %7d%n", g.group, g.tiles, g.failedTiles);
+			System.out.printf("%-58s %7d %7d%s%n", g.group, g.tiles, g.failedTiles,
+					g.renderErrors > 0 ? "   " + g.renderErrors + " renderer errors" : "");
 		}
 		System.out.printf("%d tiles compared, %d failed, %d maps loaded, %s renderer, %.1f s%n",
 				result.comparedTiles, result.failedTiles, result.loadedMaps, result.renderer,
 				result.durationMs / 1000.0);
+		if (result.renderErrors > 0) {
+			System.out.printf("%d tiles could not be rendered at all, the renderer died %d times -"
+					+ " see the report, that is a bug of the renderer%n",
+					result.renderErrors, result.rendererDeaths);
+		}
 		System.out.println(result.failedTiles > 0
 				? "COASTLINE PROBLEMS REPRODUCED - exit code 2"
-				: "No coastline problems found - exit code 0");
+				: result.renderErrors > 0
+						? "RENDERER ERRORS - exit code 2"
+						: "No coastline problems found - exit code 0");
 	}
 
 	private static String trim(String s, int len) {
@@ -1726,10 +1795,12 @@ public class CoastlineRenderingTester {
 		sb.append("<title>OsmAnd coastline tiles</title>\n");
 		sb.append("<link rel=\"stylesheet\" href=\"" + REPORT_CSS_FILE + "\">\n</head><body>\n");
 		sb.append("<header><h1>Coastline rendering &mdash; epic 3291</h1>");
-		sb.append(String.format("<p class=\"sum\"><b class=\"%s\">%d failed</b> &middot; %d tiles compared "
+		sb.append(String.format("<p class=\"sum\"><b class=\"%s\">%d failed</b>%s &middot; %d tiles compared "
 						+ "&middot; %d maps &middot; %s renderer &middot; style %s &middot; %.1f s &middot; %s</p>",
-				result.failedTiles > 0 ? "bad" : "good", result.failedTiles, result.comparedTiles,
-				result.loadedMaps, esc(result.renderer), esc(result.style),
+				result.failedTiles > 0 ? "bad" : "good", result.failedTiles,
+				result.renderErrors > 0 ? String.format(" &middot; <b class=\"bad\">%d renderer "
+						+ "errors</b> (%d crashes)", result.renderErrors, result.rendererDeaths) : "",
+				result.comparedTiles, result.loadedMaps, esc(result.renderer), esc(result.style),
 				result.durationMs / 1000.0, new java.util.Date()));
 		if (result.groups.size() > 1) {
 			StringBuilder g = new StringBuilder();

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/EyePieceTileRenderer.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/render/EyePieceTileRenderer.java
@@ -45,6 +45,28 @@ import javax.imageio.ImageIO;
  */
 class EyePieceTileRenderer implements Closeable {
 
+	/**
+	 * One tile could not be rendered because eyepiece died on it - the run goes on with the next
+	 * tile on a restarted process. A crash of the renderer is a defect worth reporting, so such
+	 * tiles are counted and named in the report instead of being dropped silently.
+	 */
+	static class TileRenderFailure extends IOException {
+		private static final long serialVersionUID = 1L;
+
+		TileRenderFailure(String message) {
+			super(message);
+		}
+	}
+
+	/** Thrown when the process is gone; {@link #render} decides whether that ends the run. */
+	private static class EyePieceDied extends IOException {
+		private static final long serialVersionUID = 1L;
+
+		EyePieceDied(String message) {
+			super(message);
+		}
+	}
+
 	/** Answer of eyepiece for one tile - see the tiles mode of EyePiece.cpp. */
 	private static final String TILE_PREFIX = "TILE ";
 
@@ -57,10 +79,17 @@ class EyePieceTileRenderer implements Closeable {
 	/** How long a process gets to leave on its own once its stdin is closed. */
 	private static final int STOP_TIMEOUT_SECONDS = 30;
 
+	/**
+	 * Deaths of the process before the whole run is given up. A restart costs the obf scan of every
+	 * map, so a binary that dies on every tile must not keep a run going for days.
+	 */
+	private static final int MAX_DEATHS = 50;
+
 	private final File binary;
 	private final File stylesPath;
 	private final String styleName;
 	private final int tileSize;
+	private final boolean symbols;
 	private final File mapsLinkDir;
 	private final File tilesDir;
 	private final boolean verbose;
@@ -74,13 +103,15 @@ class EyePieceTileRenderer implements Closeable {
 	/** The maps changed (or nothing was started yet), so the process has to be restarted. */
 	private boolean restartNeeded = true;
 	private int startCount;
+	private int deathCount;
 
-	EyePieceTileRenderer(File binary, File stylesPath, String styleName, int tileSize, File workDir,
-			boolean verbose) {
+	EyePieceTileRenderer(File binary, File stylesPath, String styleName, int tileSize,
+			boolean symbols, File workDir, boolean verbose) {
 		this.binary = binary;
 		this.stylesPath = stylesPath;
 		this.styleName = styleName;
 		this.tileSize = tileSize;
+		this.symbols = symbols;
 		this.mapsLinkDir = new File(workDir, "opengl-maps");
 		this.tilesDir = new File(workDir, "opengl-tiles");
 		this.verbose = verbose;
@@ -96,12 +127,66 @@ class EyePieceTileRenderer implements Closeable {
 		}
 	}
 
-	/** Renders one tile of the {@code z/x/y} scheme, 256x256 by default. */
+	/**
+	 * Renders one tile of the {@code z/x/y} scheme, 256x256 by default.
+	 *
+	 * <p>eyepiece dying is not the end of the run: rendering a tile can hit a bug of core (a Qt
+	 * assert, a segfault) and thousands of tiles must not be lost to one of them. The process is
+	 * restarted and the tile is tried once more - a crash can come from the state left by the
+	 * previous tiles and then does not repeat on a fresh process - and if it dies again the tile is
+	 * reported as a {@link TileRenderFailure} and the run continues.
+	 */
 	BufferedImage render(int zoom, int x, int y) throws IOException {
+		try {
+			return renderOnce(zoom, x, y);
+		} catch (EyePieceDied first) {
+			deathCount++;
+			System.err.println("  " + first.getMessage());
+			if (deathCount > MAX_DEATHS) {
+				throw new IOException("eyepiece died " + deathCount + " times, giving up", first);
+			}
+			System.err.printf("  restarting eyepiece and retrying %d/%d/%d%n", zoom, x, y);
+			try {
+				return renderOnce(zoom, x, y);
+			} catch (EyePieceDied second) {
+				deathCount++;
+				throw new TileRenderFailure("eyepiece dies on " + zoom + "/" + x + "/" + y + " - "
+						+ lastMeaningfulLine(second.getMessage()));
+			}
+		}
+	}
+
+	/** How many times eyepiece died during the run. */
+	int deaths() {
+		return deathCount;
+	}
+
+	/**
+	 * The line of the output that says what went wrong - the assert or the signal, not the last
+	 * {@code TILE} line before it, which is only the tile that went through.
+	 */
+	private static String lastMeaningfulLine(String output) {
+		String[] lines = output.split("\n");
+		for (int i = lines.length - 1; i >= 0; i--) {
+			String l = lines[i].trim();
+			if (!l.isEmpty() && !l.startsWith(TILE_PREFIX)) {
+				return l;
+			}
+		}
+		return output;
+	}
+
+	private BufferedImage renderOnce(int zoom, int x, int y) throws IOException {
 		ensureStarted();
 		String tile = zoom + "/" + x + "/" + y;
-		toProcess.write(tile + "\n");
-		toProcess.flush();
+		try {
+			toProcess.write(tile + "\n");
+			toProcess.flush();
+		} catch (IOException e) {
+			// the process died between two tiles, its output went with it
+			stop();
+			throw new EyePieceDied("eyepiece is gone before " + tile + ": " + e.getMessage());
+		}
 		String answer = readAnswer(tile);
 		File png = new File(answer);
 		if (!png.isFile()) {
@@ -136,7 +221,7 @@ class EyePieceTileRenderer implements Closeable {
 					Thread.currentThread().interrupt();
 				}
 				stop();
-				throw new IOException("eyepiece died (exit code " + code + ") on tile " + tile
+				throw new EyePieceDied("eyepiece died (exit code " + code + ") on tile " + tile
 						+ ", last output:\n" + String.join("\n", lastLines));
 			}
 			keepLine(line);
@@ -181,6 +266,11 @@ class EyePieceTileRenderer implements Closeable {
 		cmd.add("-tiles=-");
 		cmd.add("-tilesOutputDir=" + tilesDir.getAbsolutePath());
 		cmd.add("-tileSize=" + tileSize);
+		if (!symbols) {
+			// labels and icons are 94% of the time of a v2 tile (measured 500 ms against 30 ms per
+			// tile) and say nothing about a coastline, so they are off unless asked for
+			cmd.add("-noSymbols");
+		}
 		process = start(cmd);
 		toProcess = new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8);
 		fromProcess = new BufferedReader(new InputStreamReader(process.getInputStream(),
@@ -206,11 +296,14 @@ class EyePieceTileRenderer implements Closeable {
 	 * eyepiece older than <a href="https://github.com/osmandapp/OsmAnd-core/pull/1100">core#1100</a>
 	 * answers "Unrecognized argument: '-tiles=-'" and dies on the first tile, with its whole usage
 	 * text as the error - which is what a build server picking up a stale published binary looks
-	 * like. Started without arguments eyepiece prints that usage and exits in 0.2 s, so the check
-	 * costs nothing.
+	 * like. The check costs 0.2 s: the argument parser answers before anything is rendered.
 	 */
 	void checkBatchTileMode() throws IOException {
-		Process p = start(new ArrayList<>(List.of(binary.getAbsolutePath())));
+		// "-tiles=-" without an output dir is rejected by the argument parser of either binary,
+		// before anything is rendered: a new one asks for -tilesOutputDir, an old one does not know
+		// the argument at all. Asking about the feature itself rather than reading the usage text
+		// is what makes this work on a binary whose core is newer than its tools checkout.
+		Process p = start(new ArrayList<>(List.of(binary.getAbsolutePath(), "-tiles=-")));
 		StringBuilder usage = new StringBuilder();
 		try (BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream(),
 				StandardCharsets.UTF_8))) {
@@ -229,9 +322,7 @@ class EyePieceTileRenderer implements Closeable {
 			Thread.currentThread().interrupt();
 			throw new IOException(e);
 		}
-		// "tilesOutputDir" appears in the usage text of the tile mode and nowhere else - "-tiles="
-		// alone would also match the "Unrecognized argument: '-tiles=-'" of an old binary
-		if (usage.indexOf("tilesOutputDir") < 0) {
+		if (usage.indexOf("Unrecognized argument") >= 0) {
 			throw new IOException(binary.getAbsolutePath() + " has no batch tile mode (-tiles),"
 					+ " it is older than https://github.com/osmandapp/OsmAnd-core/pull/1100."
 					+ " Take a newer build - the build server publishes one at"


### PR DESCRIPTION
Everything the first opengl runs of `Web_Ocean_Tiles_Test` asked for. Includes #1676 (it is based on
that branch); needs osmandapp/OsmAnd-core#1102 for `-noSymbols` and, more importantly, for the idle
fix that makes the tiles complete.

### Map symbols off by default

`-symbols=true` draws them. Labels and icons are **94% of the time of a v2 tile** — measured 500 ms
per tile with them against 30 ms without, which is what the legacy renderer needs anyway — and they
say nothing about a coastline. The 276 fixed case tiles come out identical either way: the same 31
failed tiles, the same worst percentages. That makes the opengl run of the job practical: 9240
random tiles are ~5 minutes of rendering instead of ~77.

### A crash of the renderer no longer ends the run

Build [132](https://builder.osmand.net:8080/job/Web_Ocean_Tiles_Test/132/console) got through every
fixed case and then lost the whole random part to one assert inside core:

```
java.io.IOException: eyepiece died (exit code 134) on tile 16/17500/12563, last output:
ASSERT failure in QVector<T>::operator[]: "index out of range", ... qvector.h, line 453
```

eyepiece is now restarted and the tile is tried once more — a crash can come from the state left by
the previous tiles and then does not repeat — and if it dies again the tile is counted as a
**renderer error**, named in the report with the message it died with, and the run continues. 50
deaths in one run still give up.

Renderer errors make the exit code 2 the way a water difference does: a renderer that aborts on a
tile is a worse defect than a wrong coastline, and a run that quietly dropped those tiles would look
better the more broken the renderer is. They appear in `summary.json` (`renderErrors`,
`rendererDeaths`), in the console summary, and as the first entries of the html report:

```
  CRASHED 15/5267/12703 - eyepiece dies on 15/5267/12703 - ASSERT failure in QVector<T>::operator[]: "index out of range"
...
#23353 Map flooding - San Francisco                             44      15     0.00%    71.13%
                                                           1 tiles the renderer crashed on
1 tiles could not be rendered at all, the renderer died 2 times - see the report, that is a bug of the renderer
```

### The report is written after every case

Not only every `flushEvery` (1000) tiles — the fixed cases are 276, so nothing was ever written
before the random part started. Now the fixed cases can be read while the random tiles, the long
part, are still running, and a killed job leaves behind the part it finished.

### The eyepiece check asks the binary, not its usage text

`-tiles=` with no output dir, which either parser rejects at once, instead of grepping the usage
text. A binary whose core is newer than its tools checkout was rejected by the old check — my own
local build was.

Tested on macOS: the 276 fixed case tiles (31 failed, identical to the run with symbols), the crash
path against a stub that aborts on a chosen tile (restart, retry, report entry, exit code 2), and
the capability check against a stub with an old argument parser.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. The comparison with the legacy renderer seems slow.
2. It failed again, look at the logs; save the reports before the random part starts so they can be
   looked at.
3. You may switch the labels off for the ocean tiles.
4. Crashes have to be fixed too, and it is important to keep them in the report.

Decided by the agent, not requested explicitly:
- Measuring where the time of a tile goes before changing anything, and then finding that the first
  measurement of the symbols cost was wrong because the renderer was reading back unfinished frames
  (osmandapp/OsmAnd-core#1102).
- Treating renderer errors as exit code 2 rather than as skipped tiles, and giving them the top
  severity in the report.
- Retrying a crashed tile once on a fresh process, and the 50 deaths limit.
- Rewriting the capability check to ask about the feature instead of reading the usage text.

Still open: the `QVector` assert itself is a real bug in core and is not fixed here - the test now
reports it instead of dying on it.
