### PR TITLE
Follow RouteSegmentResult to OsmAnd-shared

### DIFF
--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapClusterLayer.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapClusterLayer.java
@@ -38,7 +38,7 @@ import net.osmand.router.BinaryRoutePlanner.RouteSegmentVisitor;
 import net.osmand.router.RoutePlannerFrontEnd;
 import net.osmand.router.RoutePlannerFrontEnd.GpxPoint;
 import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
-import net.osmand.router.RouteSegmentResult;
+import net.osmand.shared.routing.RouteSegmentResult;
 import net.osmand.router.RoutingConfiguration;
 import net.osmand.router.RoutingConfiguration.Builder;
 import net.osmand.router.RoutingConfiguration.RoutingMemoryLimits;

--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
@@ -100,6 +100,8 @@ import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
 import net.osmand.router.RouteResultPreparation.RouteCalcResult;
 import net.osmand.router.RoutingConfiguration.RoutingMemoryLimits;
 import net.osmand.util.MapUtils;
+import net.osmand.shared.routing.RouteSegmentResult;
+import net.osmand.shared.util.KMapUtils;
 
 
 public class MapRouterLayer implements MapPanelLayer {
@@ -1002,7 +1004,7 @@ public class MapRouterLayer implements MapPanelLayer {
 					int i = rs.getStartPointIndex(), end = rs.getEndPointIndex();
 					int step = i <= end ? 1 : -1;
 					while (i != end) {
-						d += MapUtils.getDistance(rs.getPoint(i), rs.getPoint(i + step));
+						d += KMapUtils.INSTANCE.getDistance(rs.getPoint(i), rs.getPoint(i + step));
 						i += step;
 					}
 				}
@@ -1053,7 +1055,7 @@ public class MapRouterLayer implements MapPanelLayer {
 		int i = segment.getStartPointIndex(), end = segment.getEndPointIndex();
 		int step = i <= end ? 1 : -1;
 		while (true) {
-			LatLon l = segment.getPoint(i);
+			LatLon l = LatLon.of(segment.getPoint(i));
 			w.addNode(new net.osmand.osm.edit.Node(l.getLatitude(), l.getLongitude(), -1));
 			if (i == end) {
 				break;
@@ -1370,7 +1372,7 @@ public class MapRouterLayer implements MapPanelLayer {
 				way.putTag("colour", colour);
 			}
 			if (prevSegm != null
-					&& MapUtils.getDistance(prevSegm.getEndPoint(), segm.getStartPoint()) > 0) {
+					&& KMapUtils.INSTANCE.getDistance(prevSegm.getEndPoint(), segm.getStartPoint()) > 0) {
 				net.osmand.osm.edit.Node pp = new net.osmand.osm.edit.Node(prevSegm.getEndPoint().getLatitude(), prevSegm.getEndPoint().getLongitude(), -1);
 				res.add(pp);
 				pp.putTag("colour", "blue");
@@ -1378,14 +1380,14 @@ public class MapRouterLayer implements MapPanelLayer {
 				pn.putTag("colour", "red");
 				res.add(pn);
 				System.out.println(String.format("Not connected road '%f m' (%.5f/%.5f -> %.5f/%.5f) [%d: %s -> %d: %s]",
-						MapUtils.getDistance(prevSegm.getEndPoint(), segm.getStartPoint()),
+						KMapUtils.INSTANCE.getDistance(prevSegm.getEndPoint(), segm.getStartPoint()),
 						pp.getLatLon().getLatitude(), pp.getLatLon().getLongitude(), pn.getLatLon().getLatitude(), pn.getLatLon().getLongitude(),
 						segm.getStartPointIndex(), segm.getObject(), prevSegm.getStartPointIndex(), prevSegm.getObject() ));
 			}
 			boolean plus = segm.getStartPointIndex() < segm.getEndPointIndex();
 			int ind = segm.getStartPointIndex();
 			while (true) {
-				LatLon l = segm.getPoint(ind);
+				LatLon l = LatLon.of(segm.getPoint(ind));
 				net.osmand.osm.edit.Node n = new net.osmand.osm.edit.Node(l.getLatitude(), l.getLongitude(), -1);
 
 				int[] pointTypes = segm.getObject().getPointTypes(ind);

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingUtilities.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingUtilities.java
@@ -35,6 +35,7 @@ import net.osmand.router.HHRoutingSubGraphCreator.NetworkIsland;
 import net.osmand.router.HHRoutingSubGraphCreator.RouteSegmentBorderPoint;
 import net.osmand.router.HHRoutingSubGraphCreator.RouteSegmentVertex;
 import net.osmand.util.MapUtils;
+import net.osmand.shared.routing.RouteSegmentResult;
 
 public class HHRoutingUtilities {
 	static long DEBUG_OSM_ID = -1;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteEntry.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteEntry.java
@@ -2,7 +2,7 @@ package net.osmand.router.tester;
 
 import net.osmand.shared.routing.RouteDataObject;
 import net.osmand.data.LatLon;
-import net.osmand.router.RouteSegmentResult;
+import net.osmand.shared.routing.RouteSegmentResult;
 import net.osmand.router.RoutingContext;
 import net.osmand.router.TransportRoutePlanner;
 import net.osmand.router.TransportRouteResult;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteTester.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteTester.java
@@ -25,7 +25,7 @@ import net.osmand.router.HHRoutePlanner;
 import net.osmand.router.NativeTransportRoutingResult;
 import net.osmand.router.RoutePlannerFrontEnd;
 import net.osmand.router.RouteResultPreparation;
-import net.osmand.router.RouteSegmentResult;
+import net.osmand.shared.routing.RouteSegmentResult;
 import net.osmand.router.RoutingConfiguration;
 import net.osmand.router.RoutingContext;
 import net.osmand.router.TransportRoutePlanner;

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
@@ -91,7 +91,7 @@ import net.osmand.router.RoutePlannerFrontEnd.GpxPoint;
 import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
 import net.osmand.router.RouteResultPreparation;
 import net.osmand.router.RouteResultPreparation.RouteCalcResult;
-import net.osmand.router.RouteSegmentResult;
+import net.osmand.shared.routing.RouteSegmentResult;
 import net.osmand.router.RoutingConfiguration;
 import net.osmand.router.RoutingConfiguration.Builder;
 import net.osmand.router.RoutingConfiguration.RoutingMemoryLimits;

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
@@ -31,6 +31,7 @@ import static net.osmand.gpx.GPXUtilities.GAP_PROFILE_TYPE;
 import static net.osmand.server.utils.WebGpxParser.LINE_PROFILE_TYPE;
 import static net.osmand.server.controllers.pub.GeojsonClasses.*;
 import net.osmand.shared.routing.RouteDataResources;
+import net.osmand.shared.routing.RouteSegmentResult;
 
 @Service
 public class RoutingService {
@@ -316,7 +317,7 @@ public class RoutingService {
                     double lon = r.getStartPoint().getLongitude();
                     point = Geometry.pointElevation(new LatLonEle(lat, lon, ele));
                 } else {
-                    point = Geometry.point(r.getStartPoint());
+                    point = Geometry.point(LatLon.of(r.getStartPoint()));
                 }
 
                 Feature f = new Feature(point);
@@ -401,7 +402,7 @@ public class RoutingService {
             int dir = r.isForwardDirection() ? 1 : -1;
             String description = r.getDescription(true);
             if (!Algorithms.isEmpty(description)) {
-                Feature f = new Feature(Geometry.point(r.getStartPoint()));
+                Feature f = new Feature(Geometry.point(LatLon.of(r.getStartPoint())));
                 f.prop("description", description).prop("routingTime", r.getRoutingTime())
                         .prop("segmentTime", r.getRoutingTime()).prop("segmentSpeed", r.getRoutingTime())
                         .prop("roadId", r.getObject().getId());
@@ -409,9 +410,9 @@ public class RoutingService {
             }
             for (i = r.getStartPointIndex(); ; i += dir) {
                 if(i != r.getEndPointIndex()) {
-                    resList.add(r.getPoint(i));
+                    resList.add(LatLon.of(r.getPoint(i)));
                 } else {
-                    last = r.getPoint(i);
+                    last = LatLon.of(r.getPoint(i));
                     break;
                 }
             }
@@ -509,7 +510,7 @@ public class RoutingService {
     }
 
     private void getPoint(int ind, RouteSegmentResult r, List<Location> locations, float[] heightArray, List<WebGpxParser.Point> pointsRes) {
-        LatLon point = r.getPoint(ind);
+        LatLon point = LatLon.of(r.getPoint(ind));
         locations.add(new Location("", point.getLatitude(), point.getLongitude()));
         WptPt pt = new WptPt();
         if (heightArray != null && heightArray.length > ind * 2 + 1) {

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/RoutingController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/RoutingController.java
@@ -42,7 +42,7 @@ import net.osmand.gpx.GPXUtilities;
 import net.osmand.router.GeneralRouter;
 import net.osmand.router.GeneralRouter.RoutingParameterType;
 import net.osmand.router.RouteCalculationProgress;
-import net.osmand.router.RouteSegmentResult;
+import net.osmand.shared.routing.RouteSegmentResult;
 import net.osmand.router.RoutingConfiguration;
 import net.osmand.server.api.services.OsmAndMapsService;
 import net.osmand.server.api.services.OsmAndMapsService.RoutingServerConfigEntry;


### PR DESCRIPTION
Keeps `java-tools` compiling against osmandapp/OsmAnd#25911, which moves `RouteSegmentResult` into the `OsmAnd-shared` KMP module. Stacked on #1682.

Eight files change an import. Two also follow the point accessors: `getStartPoint`, `getEndPoint` and `getPoint` answer with a `KLatLon` now, because the shared module has no `LatLon`. `MapRouterLayer` and `RoutingService` convert with the new `LatLon.of`, or measure distances with `KMapUtils` directly where the result was only fed to `MapUtils.getDistance`.

**Merge order:** osmandapp/OsmAnd-core-legacy#350, #351, #352 → OsmAndCore snapshot rebuild → the OsmAnd stack through #25909 → #1680, #1681, #1682, this.

Verified with `./gradlew compileJava compileTestJava` against the `shared-routing-8-route-segment-result` branch.

