### PR TITLE
Follow VehicleRouter to OsmAnd-shared

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/ImproveRoadConnectivity.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/ImproveRoadConnectivity.java
@@ -21,6 +21,7 @@ import net.osmand.router.RoutingConfiguration.RoutingMemoryLimits;
 import net.osmand.router.RoutingContext.RoutingSubregionTile;
 import net.osmand.util.MapUtils;
 import org.apache.commons.logging.Log;
+import net.osmand.shared.routing.VehicleRouter;
 
 
 //This map generation step adds roads to the Base routing to improve it.


### PR DESCRIPTION
Keeps `java-tools` compiling against osmandapp/OsmAnd#25912, which moves `VehicleRouter` into the `OsmAnd-shared` KMP module. Stacked on #1683.

One import, in `ImproveRoadConnectivity`, which only names the type — it calls `acceptLine`, `isOneWay` and the speed methods, none of which changed.

**Merge order:** osmandapp/OsmAnd-core-legacy#350, #351, #352 → OsmAndCore snapshot rebuild → the OsmAnd stack through #25912 → #1680 to #1683, this.

Verified with `./gradlew compileJava compileTestJava` against the `shared-routing-9a-vehicle-router` branch.
