### PR TITLE
Follow RouteCalculationProgress to OsmAnd-shared

### DIFF
--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
@@ -56,6 +56,7 @@ import net.osmand.shared.gpx.primitives.TrkSegment;
 import net.osmand.shared.gpx.primitives.WptPt;
 import net.osmand.shared.io.KFile;
 import net.osmand.shared.routing.RouteColorize.ColorizationType;
+import net.osmand.shared.routing.RouteCalculationProgress;
 import net.osmand.shared.routing.TurnType;
 import org.apache.commons.logging.Log;
 import org.json.JSONException;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingPrepareContext.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingPrepareContext.java
@@ -22,6 +22,7 @@ import net.osmand.router.HHRoutingPreparationDB.NetworkRouteRegion;
 import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
 import net.osmand.router.RoutingConfiguration.Builder;
 import net.osmand.router.RoutingConfiguration.RoutingMemoryLimits;
+import net.osmand.shared.routing.RouteCalculationProgress;
 
 public class HHRoutingPrepareContext {
 

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingShortcutCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingShortcutCreator.java
@@ -30,6 +30,7 @@ import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import net.osmand.PlatformUtil;
 import net.osmand.shared.routing.RouteRegion;
+import net.osmand.shared.routing.RouteCalculationProgress;
 import net.osmand.shared.routing.RouteSubregion;
 import net.osmand.data.LatLon;
 import net.osmand.osm.edit.Entity;

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
@@ -85,7 +85,7 @@ import net.osmand.router.GpxRouteApproximation;
 import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
 import net.osmand.router.HHRouteDataStructure.HHRoutingContext;
 import net.osmand.router.HHRouteDataStructure.NetworkDBPoint;
-import net.osmand.router.RouteCalculationProgress;
+import net.osmand.shared.routing.RouteCalculationProgress;
 import net.osmand.router.RoutePlannerFrontEnd;
 import net.osmand.router.RoutePlannerFrontEnd.GpxPoint;
 import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/RoutingService.java
@@ -14,6 +14,7 @@ import net.osmand.shared.gpx.ElevationDiffsCalculator;
 import net.osmand.shared.gpx.GpxUtilities;
 import net.osmand.shared.gpx.primitives.TrkSegment;
 import net.osmand.shared.gpx.primitives.WptPt;
+import net.osmand.shared.routing.RouteCalculationProgress;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/RoutingController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/RoutingController.java
@@ -41,7 +41,7 @@ import net.osmand.gpx.GPXFile;
 import net.osmand.gpx.GPXUtilities;
 import net.osmand.shared.routing.GeneralRouter;
 import net.osmand.shared.routing.GeneralRouter.RoutingParameterType;
-import net.osmand.router.RouteCalculationProgress;
+import net.osmand.shared.routing.RouteCalculationProgress;
 import net.osmand.shared.routing.RouteSegmentResult;
 import net.osmand.router.RoutingConfiguration;
 import net.osmand.server.api.services.OsmAndMapsService;

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/UserSessionResources.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/UserSessionResources.java
@@ -19,7 +19,7 @@ import net.osmand.shared.gpx.GpxTrackAnalysis;
 import net.osmand.shared.gpx.primitives.Metadata;
 import org.springframework.stereotype.Component;
 
-import net.osmand.router.RouteCalculationProgress;
+import net.osmand.shared.routing.RouteCalculationProgress;
 
 @WebListener
 @Component


### PR DESCRIPTION
Stacked on #1685, review that one first. Follows osmandapp/OsmAnd#25917.

`RouteCalculationProgress` moved from `net.osmand.router` to `net.osmand.shared.routing`, together with `FastRoutingState`. Imports only, in seven files across `OsmAndMapCreator`, `OsmAndMapCreatorUtilities` and `OsmAndServer`.

All four java-tools projects compile.

Merges after the OsmAnd side.
