### PR TITLE
Follow PrecalculatedRouteDirection and RouteConditionalHelper to OsmAnd-shared

### DIFF
--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
@@ -62,6 +62,7 @@ import net.osmand.shared.routing.DirectionPoint;
 import net.osmand.shared.routing.RouteCalculationProgress;
 import net.osmand.shared.routing.TurnType;
 import net.osmand.shared.routing.RoutingConfiguration;
+import net.osmand.shared.routing.PrecalculatedRouteDirection;
 import org.apache.commons.logging.Log;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingPrepareContext.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingPrepareContext.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static net.osmand.router.HHRoutingUtilities.logf;
-import static net.osmand.router.RouteConditionalHelper.RULE_INT_MAX;
+import static net.osmand.shared.routing.RouteConditionalHelper.RULE_INT_MAX;
 
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.router.HHRoutingPreparationDB.NetworkRouteRegion;


### PR DESCRIPTION
Stacked on #1688, review that one first. Follows osmandapp/OsmAnd#25922.

`PrecalculatedRouteDirection` and `RouteConditionalHelper` moved from `net.osmand.router` to `net.osmand.shared.routing`. Imports only, in two files — `HHRoutingPrepareContext` also static-imports `RULE_INT_MAX` from the helper.

All four java-tools projects compile, tests included.

Merges after the OsmAnd side.
