### PR TITLE
Follow RouteCalculationMode into net.osmand.shared.routing

### DIFF
--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapClusterLayer.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapClusterLayer.java
@@ -37,7 +37,7 @@ import net.osmand.router.BinaryRoutePlanner.RouteSegment;
 import net.osmand.router.BinaryRoutePlanner.RouteSegmentVisitor;
 import net.osmand.router.RoutePlannerFrontEnd;
 import net.osmand.router.RoutePlannerFrontEnd.GpxPoint;
-import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
+import net.osmand.shared.routing.RouteCalculationMode;
 import net.osmand.shared.routing.RouteSegmentResult;
 import net.osmand.shared.routing.RoutingConfiguration;
 import net.osmand.shared.routing.RoutingConfiguration.Builder;

--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
@@ -100,7 +100,7 @@ import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
 import net.osmand.router.HHRouteDataStructure.HHRoutingContext;
 import net.osmand.router.HHRouteDataStructure.NetworkDBPoint;
 import net.osmand.router.RoutePlannerFrontEnd.GpxPoint;
-import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
+import net.osmand.shared.routing.RouteCalculationMode;
 import net.osmand.router.RouteResultPreparation.RouteCalcResult;
 import net.osmand.shared.routing.RoutingConfiguration.RoutingMemoryLimits;
 import net.osmand.util.MapUtils;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/ImproveRoadConnectivity.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/obf/preparation/ImproveRoadConnectivity.java
@@ -16,7 +16,7 @@ import net.osmand.shared.routing.RoutingConfiguration;
 import net.osmand.impl.ConsoleProgressImplementation;
 import net.osmand.router.*;
 import net.osmand.router.BinaryRoutePlanner.RouteSegment;
-import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
+import net.osmand.shared.routing.RouteCalculationMode;
 import net.osmand.shared.routing.RoutingConfiguration.Builder;
 import net.osmand.shared.routing.RoutingConfiguration.RoutingMemoryLimits;
 import net.osmand.router.RoutingContext.RoutingSubregionTile;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingPrepareContext.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingPrepareContext.java
@@ -19,7 +19,7 @@ import static net.osmand.shared.routing.RouteConditionalHelper.RULE_INT_MAX;
 
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.router.HHRoutingPreparationDB.NetworkRouteRegion;
-import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
+import net.osmand.shared.routing.RouteCalculationMode;
 import net.osmand.shared.routing.RoutingConfiguration.Builder;
 import net.osmand.shared.routing.RoutingConfiguration.RoutingMemoryLimits;
 import net.osmand.shared.routing.RouteCalculationProgress;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteTester.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteTester.java
@@ -36,6 +36,7 @@ import net.osmand.util.Algorithms;
 
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.util.MapUtils;
+import net.osmand.shared.routing.RouteCalculationMode;
 
 public class RandomRouteTester {
 	static final String PUBLIC_TRANSPORT_PROFILE = "public_transport";
@@ -551,10 +552,8 @@ public class RandomRouteTester {
 
 		RoutingConfiguration config = buildRoutingConfiguration(builder, entry, memoryLimits);
 
-		RoutePlannerFrontEnd.RouteCalculationMode mode =
-				(this.config.CAR_2PHASE_MODE && "car".equals(entry.profile)) ?
-						RoutePlannerFrontEnd.RouteCalculationMode.COMPLEX :
-						RoutePlannerFrontEnd.RouteCalculationMode.NORMAL;
+		RouteCalculationMode mode = (this.config.CAR_2PHASE_MODE && "car".equals(entry.profile)) ?
+				RouteCalculationMode.COMPLEX : RouteCalculationMode.NORMAL;
 
 		if (this.config.USE_TIME_CONDITIONAL_ROUTING == 1) {
 			config.routeCalculationTime = System.currentTimeMillis();
@@ -630,7 +629,7 @@ public class RandomRouteTester {
 				config,
 				useNative ? nativeLibrary : null,
 				obfReaders.toArray(new BinaryMapIndexReader[0]),
-				RoutePlannerFrontEnd.RouteCalculationMode.NORMAL
+				RouteCalculationMode.NORMAL
 		);
 		applyImpassableRoads(ctx, entry);
 

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/util/ManyToOneRoadCalculation.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/util/ManyToOneRoadCalculation.java
@@ -24,7 +24,7 @@ import net.osmand.router.BinaryRoutePlanner;
 import net.osmand.router.BinaryRoutePlanner.RouteSegment;
 import net.osmand.shared.routing.GeneralRouter;
 import net.osmand.router.RoutePlannerFrontEnd;
-import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
+import net.osmand.shared.routing.RouteCalculationMode;
 import net.osmand.shared.routing.RoutingConfiguration;
 import net.osmand.shared.routing.RoutingConfiguration.RoutingMemoryLimits;
 import net.osmand.router.RoutingContext;

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
@@ -88,7 +88,7 @@ import net.osmand.router.HHRouteDataStructure.NetworkDBPoint;
 import net.osmand.shared.routing.RouteCalculationProgress;
 import net.osmand.router.RoutePlannerFrontEnd;
 import net.osmand.router.RoutePlannerFrontEnd.GpxPoint;
-import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
+import net.osmand.shared.routing.RouteCalculationMode;
 import net.osmand.router.RouteResultPreparation;
 import net.osmand.router.RouteResultPreparation.RouteCalcResult;
 import net.osmand.shared.routing.RouteSegmentResult;


### PR DESCRIPTION
Stacked on #1689.

`RouteCalculationMode` moved out of `RoutePlannerFrontEnd`, where it was nested, into a class of its own in `OsmAnd-shared`, so the C++ router can keep reading it once the routing context is split. Import changes only.

`java-tools` builds `OsmAnd-java` and `OsmAnd-shared` from source, so it has to follow. `compileJava` and `compileTestJava` pass.

Pairs with osmandapp/OsmAnd#25949 and merges after it.