### PR TITLE
Follow HHRoutingConfig into net.osmand.shared.routing

### DIFF
--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
@@ -835,7 +835,11 @@ public class MapRouterLayer implements MapPanelLayer {
 					router.setUseOnlyHHRouting(true).setHHRoutingConfig(hhConfig);
 					res = selfRoute(startRoute, endRoute, intermediates, false, previousRoute, router,  m);
 					if (USE_CACHE_CONTEXT) {
-						cacheHHCtx = hhConfig.cacheCtx;
+						// HHRoutingConfig is in OsmAnd-shared now and carries the context as an Object:
+						// HHRoutingContext holds BinaryMapIndexReaders and stays in net.osmand.router
+						@SuppressWarnings("unchecked")
+						HHRoutingContext<NetworkDBPoint> cached = (HHRoutingContext<NetworkDBPoint>) hhConfig.cacheCtx;
+						cacheHHCtx = cached;
 					}
 				} else {
 					router.setUseOnlyHHRouting(false).setHHRoutingConfig(null);

--- a/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
+++ b/java-tools/OsmAndMapCreator/src/main/java/net/osmand/swing/MapRouterLayer.java
@@ -96,7 +96,7 @@ import net.osmand.router.BinaryRoutePlanner.RouteSegment;
 import net.osmand.router.BinaryRoutePlanner.RouteSegmentVisitor;
 import net.osmand.router.HHRouteDataStructure.HHNetworkRouteRes;
 import net.osmand.router.HHRouteDataStructure.HHNetworkSegmentRes;
-import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
+import net.osmand.shared.routing.HHRoutingConfig;
 import net.osmand.router.HHRouteDataStructure.HHRoutingContext;
 import net.osmand.router.HHRouteDataStructure.NetworkDBPoint;
 import net.osmand.router.RoutePlannerFrontEnd.GpxPoint;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingTopGraphCreator.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/HHRoutingTopGraphCreator.java
@@ -18,7 +18,7 @@ import org.apache.commons.logging.Log;
 import gnu.trove.map.hash.TIntIntHashMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import net.osmand.PlatformUtil;
-import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
+import net.osmand.shared.routing.HHRoutingConfig;
 import net.osmand.router.HHRouteDataStructure.HHRoutingContext;
 import net.osmand.router.HHRouteDataStructure.NetworkDBPoint;
 import net.osmand.router.HHRouteDataStructure.NetworkDBSegment;

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/TestHHRouting.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/TestHHRouting.java
@@ -12,7 +12,7 @@ import net.osmand.obf.preparation.DBDialect;
 import net.osmand.osm.edit.Entity;
 import net.osmand.router.HHRouteDataStructure.HHNetworkRouteRes;
 import net.osmand.router.HHRouteDataStructure.HHNetworkSegmentRes;
-import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
+import net.osmand.shared.routing.HHRoutingConfig;
 
 public class TestHHRouting {
 	

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteTester.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteTester.java
@@ -599,7 +599,7 @@ public class RandomRouteTester {
 		long started = System.currentTimeMillis();
 
 		HHRoutePlanner.DEBUG_VERBOSE_LEVEL = 1;
-		HHRouteDataStructure.HHRoutingConfig.STATS_VERBOSE_LEVEL = 1;
+		HHRoutingConfig.STATS_VERBOSE_LEVEL = 1;
 		RouteResultPreparation.PRINT_TO_CONSOLE_ROUTE_INFORMATION = true;
 
 		RoutePlannerFrontEnd fe = new RoutePlannerFrontEnd();

--- a/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteTester.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/main/java/net/osmand/router/tester/RandomRouteTester.java
@@ -20,6 +20,7 @@ import net.osmand.MainUtilities.CommandLineOpts;
 import net.osmand.PlatformUtil;
 import net.osmand.NativeLibrary;
 import net.osmand.shared.routing.GeneralRouter;
+import net.osmand.shared.routing.HHRoutingConfig;
 import net.osmand.router.HHRouteDataStructure;
 import net.osmand.router.HHRoutePlanner;
 import net.osmand.router.NativeTransportRoutingResult;

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/Application.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/Application.java
@@ -26,7 +26,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 import kotlinx.serialization.json.Json;
 import kotlinx.serialization.json.Json.Default;
-import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
+import net.osmand.shared.routing.HHRoutingConfig;
 import net.osmand.router.HHRoutePlanner;
 import net.osmand.router.RouteResultPreparation;
 import net.osmand.server.api.services.StorageService;

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
@@ -82,7 +82,7 @@ import net.osmand.shared.routing.GeneralRouter;
 import net.osmand.shared.routing.GeneralRouter.RoutingParameter;
 import net.osmand.shared.routing.GeneralRouter.RoutingParameterType;
 import net.osmand.router.GpxRouteApproximation;
-import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
+import net.osmand.shared.routing.HHRoutingConfig;
 import net.osmand.router.HHRouteDataStructure.HHRoutingContext;
 import net.osmand.router.HHRouteDataStructure.NetworkDBPoint;
 import net.osmand.shared.routing.RouteCalculationProgress;

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
@@ -1285,7 +1285,10 @@ public class OsmAndMapsService {
 		synchronized (routingCaches) {
 			for (RoutingCacheContext c : routingCaches) {
 				if (c.rCtx == ctx) {
-					c.hCtx = c.hhConfig.cacheCtx;
+					// HHRoutingConfig is in OsmAnd-shared now and carries the context as an Object
+					@SuppressWarnings("unchecked")
+					HHRoutingContext<NetworkDBPoint> cached = (HHRoutingContext<NetworkDBPoint>) c.hhConfig.cacheCtx;
+					c.hCtx = cached;
 					c.locked = 0;
 					return true;
 				}


### PR DESCRIPTION
Stacked on #1691.

`HHRoutingConfig` moved out of `HHRouteDataStructure`, where it was nested, into a class of its own in `OsmAnd-shared`, because the C++ router reads fourteen of its fields and it is one of the two arguments `nativeRouting` takes. Import changes only.

`java-tools` builds `OsmAnd-java` and `OsmAnd-shared` from source, so it has to follow. `compileJava` and `compileTestJava` pass.

Pairs with osmandapp/OsmAnd#25950 and merges after it.