### PR TITLE
Spatial search tests: keep the golden lists on the lexicographic ladder

### DIFF
--- a/java-tools/OsmAndMapCreatorUtilities/src/test/java/net/osmand/search/SpatialSearchPipelineTest.java
+++ b/java-tools/OsmAndMapCreatorUtilities/src/test/java/net/osmand/search/SpatialSearchPipelineTest.java
@@ -1209,6 +1209,9 @@ public class SpatialSearchPipelineTest {
 				settings.LIMIT_STOP_GOALS_LEVEL_1__WHEN_REACHED_RES);
 		settings.LIMIT_STOP_GOALS_LEVEL_1__WHEN_REACHED_RES = settingsJson.optInt("LIMIT_GOAL_LEVEL_2", settings.LIMIT_STOP_GOALS_LEVEL_1__WHEN_REACHED_RES);
 		settings.DEV_USE_PIPELINE = settingsJson.optBoolean("DEV_USE_PIPELINE", settings.DEV_USE_PIPELINE);
+		// the golden lists here are recorded with the lexicographic ladder, so the score ranking is
+		// off by default and a test that wants it asks for it
+		settings.SCORE_RANKING = settingsJson.optBoolean("SCORE_RANKING", false);
 
 		return settings;
 	}


### PR DESCRIPTION
`SpatialSearchPipelineTest` and `SpatialSearchCombinationsTest` compare against lists recorded with the old comparator ladder. OsmAnd#25954 turns the score ranking on by default, which reorders 43 of the 74 files, so the tests now ask for the ladder explicitly and the score is covered by `SpatialSearchPreferencesTest` instead. A single test can opt in with `"SCORE_RANKING": true` in its settings.

**Merge together with OsmAnd#25954** — `SpatialTextSearchSettings.SCORE_RANKING` is added there, so this branch does not compile before it, and #25954 breaks these tests without it.

The deduplication in #25954 changes results with the score off as well; those lists are re-recorded in osmandapp/resources (linked below).

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Fix the ranking defects found while reviewing contrastive pairs (a transport stop above its street, a famous hotel below an unnamed park, a suburb shown instead of the city in brackets).
2. Show which golden tests differ and make a page to review them.
3. Open a PR for the tools tests with a cross-link, so they are merged at the same time.

Decided by the agent, not requested explicitly: reading the flag from the test's own settings json (so a single test can opt in) rather than from an environment variable.