### PR TITLE
Add MVT map objects context menu

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/TransportStopsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/TransportStopsService.java
@@ -2,6 +2,9 @@ package net.osmand.server.api.services;
 
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.data.*;
+import net.osmand.osm.PoiCategory;
+import net.osmand.osm.PoiFilter;
+import net.osmand.osm.PoiType;
 import net.osmand.osm.edit.Node;
 import net.osmand.router.TransportStopsRouteReader;
 import net.osmand.server.api.services.search.MapReadersService;
@@ -26,6 +29,14 @@ public class TransportStopsService {
 	private static final int SHOW_NEARBY_ROUTES_RADIUS_METERS = 150;
 	private static final int SEARCH_STOP_RADIUS_METERS = 50;
 	private static final String KEY_NEARBY_ROUTES = "nearbyRoutes";
+	// as in Android TransportStopHelper
+	private static final int SHOW_STOPS_RADIUS_METERS = 150;
+	private static final int SHOW_SUBWAY_STOPS_FROM_ENTRANCES_RADIUS_METERS = 400;
+	private static final int MAX_DISTANCE_BETWEEN_AMENITY_AND_LOCAL_STOPS = 20;
+	private static final String TRANSPORTATION_CATEGORY = "transportation";
+	private static final String PUBLIC_TRANSPORT_FILTER = "public_transport";
+	private static final String PUBLIC_TRANSPORT_STATION_SUBTYPE = "public_transport_station";
+	private static final List<String> SUBWAY_ENTRANCE_SUBTYPES = List.of("subway_entrance", PUBLIC_TRANSPORT_STATION_SUBTYPE);
 
 	private static List<LatLon> bboxAroundPoint(double lat, double lon, int radiusMeters) {
 		QuadRect rect = MapUtils.calculateLatLonBbox(lat, lon, radiusMeters);
@@ -109,7 +120,7 @@ public class TransportStopsService {
 	}
 
 	public GeojsonClasses.Feature getTransportStop(LatLon transportStopCoords, long stopId) throws IOException {
-		List<LatLon> bbox = bboxAroundPoint(transportStopCoords.getLatitude(), transportStopCoords.getLongitude(), SEARCH_STOP_RADIUS_METERS);
+		List<LatLon> bbox = bboxAroundPoint(transportStopCoords.getLatitude(), transportStopCoords.getLongitude(), SHOW_SUBWAY_STOPS_FROM_ENTRANCES_RADIUS_METERS);
 		TransportStopsReaderResult readerResult = getTransportStopsReader(bbox);
 		if (readerResult == null) {
 			return null;
@@ -124,6 +135,67 @@ public class TransportStopsService {
 			osmAndMapsService.unlockReaders(readerResult.readers);
 		}
 		return null;
+	}
+
+	public boolean isPublicTransportStop(Amenity amenity) {
+		PoiCategory category = amenity.getType();
+		if (!TRANSPORTATION_CATEGORY.equals(category.getKeyName())) {
+			return false;
+		}
+		PoiFilter filter = category.getPoiFilterByName(PUBLIC_TRANSPORT_FILTER);
+		if (filter == null) {
+			return false;
+		}
+		for (PoiType type : filter.getPoiTypes()) {
+			if (type.getKeyName().equals(amenity.getSubType())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public Long findBestTransportStopId(Amenity amenity) throws IOException {
+		LatLon loc = amenity.getLocation();
+		boolean isSubwayEntrance = SUBWAY_ENTRANCE_SUBTYPES.contains(amenity.getSubType());
+		int radius = isSubwayEntrance ? SHOW_SUBWAY_STOPS_FROM_ENTRANCES_RADIUS_METERS : SHOW_STOPS_RADIUS_METERS;
+		TransportStopsReaderResult readerResult = getTransportStopsReader(bboxAroundPoint(loc.getLatitude(), loc.getLongitude(), radius));
+		if (readerResult == null) {
+			return null;
+		}
+		try {
+			List<TransportStop> stops = new ArrayList<>(readerResult.transportReaders.readMergedTransportStops(readerResult.request));
+			stops.sort(Comparator.comparingDouble(s -> MapUtils.getDistance(s.getLocation(), loc)));
+			for (TransportStop stop : stops) {
+				if (isSubwayEntrance ? isStopOfStation(stop, amenity) : isStopOfAmenity(stop, amenity)) {
+					return stop.getId();
+				}
+			}
+			return stops.isEmpty() ? null : stops.get(0).getId();
+		} finally {
+			osmAndMapsService.unlockReaders(readerResult.readers);
+		}
+	}
+
+	private static boolean isStopOfAmenity(TransportStop stop, Amenity amenity) {
+		LatLon loc = amenity.getLocation();
+		String stopName = stop.getName().toLowerCase();
+		String amenityName = amenity.getName().toLowerCase();
+		boolean sameName = stopName.contains(amenityName) || amenityName.contains(stopName);
+		return (sameName && MapUtils.getDistance(stop.getLocation(), loc) < MAX_DISTANCE_BETWEEN_AMENITY_AND_LOCAL_STOPS)
+				|| stop.getLocation().equals(loc);
+	}
+
+	private static boolean isStopOfStation(TransportStop stop, Amenity amenity) {
+		if (PUBLIC_TRANSPORT_STATION_SUBTYPE.equals(amenity.getSubType())
+				&& (stop.getName().equals(amenity.getName()) || stop.getEnName(false).equals(amenity.getEnName(false)))) {
+			return true;
+		}
+		for (TransportStopExit exit : stop.getExits()) {
+			if (MapUtils.getDistance(exit.getLocation(), amenity.getLocation()) < MapUtils.ROUNDING_ERROR) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public Map<String, Object> getNearbyTransportStops(LatLon stopCoords, long excludeStopId) throws IOException {
@@ -239,11 +311,14 @@ public class TransportStopsService {
 	public record TransportStopInfo(long id, double lat, double lon) {
 	}
 
-	public record TransportStopRouteFeature(long id, String name, String type, String ref, String color, TransportStopInfo stop) {
+	public record TransportStopRouteFeature(long id, String name, String type, String ref, String color,
+	                                        TransportStopInfo stop) {
 	}
 
-	public record TransportStopWithDetails(long stopId, String name, LatLon coords) {}
+	public record TransportStopWithDetails(long stopId, String name, LatLon coords) {
+	}
 
-	public record TransportRouteFeature(long id, Integer intervalSeconds, List<TransportStopWithDetails> stops, List<List<LatLon>> nodes) {
+	public record TransportRouteFeature(long id, Integer intervalSeconds, List<TransportStopWithDetails> stops,
+	                                    List<List<LatLon>> nodes) {
 	}
 }

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/PoiSearchService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/PoiSearchService.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import net.osmand.CollatorStringMatcher;
+import net.osmand.NativeLibrary.RenderedObject;
 import net.osmand.ResultMatcher;
 import net.osmand.binary.BinaryIndexPart;
 import net.osmand.binary.BinaryMapIndexReader;
@@ -37,6 +38,8 @@ import net.osmand.data.QuadRect;
 import net.osmand.osm.PoiType;
 import net.osmand.osm.MapPoiTypes;
 import net.osmand.osm.PoiCategory;
+import net.osmand.osm.edit.EntityParser;
+import net.osmand.osm.edit.Node;
 import net.osmand.search.core.ObjectType;
 import net.osmand.search.core.SearchResult;
 import net.osmand.search.core.spatial.SpatialPoiSearch;
@@ -82,6 +85,9 @@ public class PoiSearchService {
 
 	@Autowired
 	private TransportStopsService transportStopsService;
+
+	@Autowired
+	private PoiTypesService poiTypesService;
 
 	public static class PoiSearchResult {
 
@@ -511,9 +517,10 @@ public class PoiSearchService {
 				return false;
 			}
 		});
-		if (res == null) {
-			return null;
-		}
+		return res != null ? getMapObjectFeature(res, timeZone) : null;
+	}
+
+	private Feature getMapObjectFeature(SearchResult res, String timeZone) throws IOException {
 		Feature feature = searchResultConverter.getPoiFeature(res, timeZone);
 		Amenity amenity = (Amenity) res.object;
 		if (feature != null && transportStopsService.isPublicTransportStop(amenity)) {
@@ -523,6 +530,24 @@ public class PoiSearchService {
 			}
 		}
 		return feature;
+	}
+
+	// vector tile object that is not in the POI index (no_indx types, buildings, ...): amenity from its tags as the map creator does
+	public Feature getPoiByTags(Map<String, String> tags, LatLon loc, long mapObjectId, String timeZone) throws IOException {
+		Node node = new Node(loc.getLatitude(), loc.getLongitude(), -1);
+		node.replaceTags(tags);
+		MapPoiTypes poiTypes = poiTypesService.getMapPoiTypes(PoiTypesService.DEFAULT_SEARCH_LANG);
+		List<Amenity> amenities = EntityParser.parseAmenities(poiTypes, node, tags, new ArrayList<>(), false);
+		if (amenities.isEmpty()) {
+			return null;
+		}
+		Amenity amenity = amenities.get(0);
+		RenderedObject renderedObject = new RenderedObject();
+		renderedObject.setId(mapObjectId);
+		amenity.setId(ObfConstants.createMapObjectIdFromCleanOsmId(ObfConstants.getOsmObjectId(renderedObject),
+				ObfConstants.getOsmEntityType(renderedObject)));
+		return getMapObjectFeature(
+				searchResultConverter.buildPoiSearchResult(amenity, PoiTypesService.DEFAULT_SEARCH_LANG, ""), timeZone);
 	}
 
 	public Feature searchPoiByEnName(LatLon loc, String enName) throws IOException {

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/PoiSearchService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/PoiSearchService.java
@@ -38,6 +38,7 @@ import net.osmand.data.QuadRect;
 import net.osmand.osm.PoiType;
 import net.osmand.osm.MapPoiTypes;
 import net.osmand.osm.PoiCategory;
+import net.osmand.osm.edit.Entity.EntityType;
 import net.osmand.osm.edit.EntityParser;
 import net.osmand.osm.edit.Node;
 import net.osmand.search.core.ObjectType;
@@ -503,9 +504,13 @@ public class PoiSearchService {
 
 	public Feature searchPoiByOsmId(LatLon loc, long osmid, String type, String timeZone) throws IOException {
 		final String NODE_TYPE = "1";
+		return searchPoiByOsmId(loc, osmid, NODE_TYPE.equals(type) ? EntityType.NODE : EntityType.WAY, timeZone);
+	}
+
+	private Feature searchPoiByOsmId(LatLon loc, long osmid, EntityType type, String timeZone) throws IOException {
 		final double WAY_SEARCH_RADIUS = 0.0055; // ~600 meters, way/relation amenity is located at its centroid
 		final double NODE_SEARCH_RADIUS = 0.0001; // ~11 meters
-		double radiusDegree = NODE_TYPE.equals(type) ? NODE_SEARCH_RADIUS : WAY_SEARCH_RADIUS;
+		double radiusDegree = type == EntityType.NODE ? NODE_SEARCH_RADIUS : WAY_SEARCH_RADIUS;
 		SearchResult res = searchSinglePoi(loc, radiusDegree, new ResultMatcher<>() {
 			@Override
 			public boolean publish(Amenity amenity) {
@@ -523,7 +528,7 @@ public class PoiSearchService {
 	private Feature getMapObjectFeature(SearchResult res, String timeZone) throws IOException {
 		Feature feature = searchResultConverter.getPoiFeature(res, timeZone);
 		Amenity amenity = (Amenity) res.object;
-		if (feature != null && transportStopsService.isPublicTransportStop(amenity)) {
+		if (transportStopsService.isPublicTransportStop(amenity)) {
 			Long stopId = transportStopsService.findBestTransportStopId(amenity);
 			if (stopId != null) {
 				feature.prop(SearchResultConverter.PoiTypeField.TRANSPORT_STOP_ID.getFieldName(), stopId);
@@ -532,20 +537,24 @@ public class PoiSearchService {
 		return feature;
 	}
 
-	// vector tile object that is not in the POI index (no_indx types, buildings, ...): amenity from its tags as the map creator does
-	public Feature getPoiByTags(Map<String, String> tags, LatLon loc, long mapObjectId, String timeZone) throws IOException {
-		Node node = new Node(loc.getLatitude(), loc.getLongitude(), -1);
-		node.replaceTags(tags);
+	// vector tile object: POI from the index by its osm id, else (no_indx types, buildings, ...) an amenity from its tags as the map creator does
+	public Feature getPoiByMapObject(long mapObjectId, LatLon loc, Map<String, String> tags, String timeZone) throws IOException {
+		RenderedObject renderedObject = new RenderedObject();
+		renderedObject.setId(mapObjectId);
+		long osmId = ObfConstants.getOsmObjectId(renderedObject);
+		EntityType entityType = ObfConstants.getOsmEntityType(renderedObject);
+		Feature feature = searchPoiByOsmId(loc, osmId, entityType, timeZone);
+		if (feature != null || tags.isEmpty()) {
+			return feature;
+		}
 		MapPoiTypes poiTypes = poiTypesService.getMapPoiTypes(PoiTypesService.DEFAULT_SEARCH_LANG);
+		Node node = new Node(loc.getLatitude(), loc.getLongitude(), -1);
 		List<Amenity> amenities = EntityParser.parseAmenities(poiTypes, node, tags, new ArrayList<>(), false);
 		if (amenities.isEmpty()) {
 			return null;
 		}
 		Amenity amenity = amenities.get(0);
-		RenderedObject renderedObject = new RenderedObject();
-		renderedObject.setId(mapObjectId);
-		amenity.setId(ObfConstants.createMapObjectIdFromCleanOsmId(ObfConstants.getOsmObjectId(renderedObject),
-				ObfConstants.getOsmEntityType(renderedObject)));
+		amenity.setId(ObfConstants.createMapObjectIdFromCleanOsmId(osmId, entityType));
 		return getMapObjectFeature(
 				searchResultConverter.buildPoiSearchResult(amenity, PoiTypesService.DEFAULT_SEARCH_LANG, ""), timeZone);
 	}

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/PoiSearchService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/PoiSearchService.java
@@ -45,6 +45,7 @@ import net.osmand.search.core.spatial.SpatialSearchResult;
 import net.osmand.search.core.spatial.SpatialTextSearch.SpatialSearchResults;
 import net.osmand.search.core.spatial.SpatialTextSearch.SpatialTextSearchSettings;
 import net.osmand.server.api.services.OsmAndMapsService;
+import net.osmand.server.api.services.TransportStopsService;
 import net.osmand.server.api.services.WikiService;
 import net.osmand.server.controllers.pub.GeojsonClasses.Feature;
 import net.osmand.server.controllers.pub.GeojsonClasses.FeatureCollection;
@@ -78,6 +79,9 @@ public class PoiSearchService {
 
 	@Autowired
 	private SearchResultConverter searchResultConverter;
+
+	@Autowired
+	private TransportStopsService transportStopsService;
 
 	public static class PoiSearchResult {
 
@@ -492,11 +496,11 @@ public class PoiSearchService {
 	}
 
 	public Feature searchPoiByOsmId(LatLon loc, long osmid, String type, String timeZone) throws IOException {
-		final String RELATION_TYPE = "3";
-		final double RELATION_SEARCH_RADIUS = 0.0055; // ~600 meters
-		final double OTHER_POI_SEARCH_RADIUS = 0.0001; // ~11 meters
-		double radiusDegree = type.equals(RELATION_TYPE) ? RELATION_SEARCH_RADIUS : OTHER_POI_SEARCH_RADIUS;
-		return searchSinglePoi(loc, radiusDegree, new ResultMatcher<>() {
+		final String NODE_TYPE = "1";
+		final double WAY_SEARCH_RADIUS = 0.0055; // ~600 meters, way/relation amenity is located at its centroid
+		final double NODE_SEARCH_RADIUS = 0.0001; // ~11 meters
+		double radiusDegree = NODE_TYPE.equals(type) ? NODE_SEARCH_RADIUS : WAY_SEARCH_RADIUS;
+		SearchResult res = searchSinglePoi(loc, radiusDegree, new ResultMatcher<>() {
 			@Override
 			public boolean publish(Amenity amenity) {
 				return ObfConstants.getOsmObjectId(amenity) == osmid;
@@ -506,12 +510,24 @@ public class PoiSearchService {
 			public boolean isCancelled() {
 				return false;
 			}
-		}, timeZone);
+		});
+		if (res == null) {
+			return null;
+		}
+		Feature feature = searchResultConverter.getPoiFeature(res, timeZone);
+		Amenity amenity = (Amenity) res.object;
+		if (feature != null && transportStopsService.isPublicTransportStop(amenity)) {
+			Long stopId = transportStopsService.findBestTransportStopId(amenity);
+			if (stopId != null) {
+				feature.prop(SearchResultConverter.PoiTypeField.TRANSPORT_STOP_ID.getFieldName(), stopId);
+			}
+		}
+		return feature;
 	}
 
 	public Feature searchPoiByEnName(LatLon loc, String enName) throws IOException {
 		final double SEARCH_RADIUS_DEGREE = 0.0001;
-		return searchSinglePoi(loc, SEARCH_RADIUS_DEGREE, new ResultMatcher<>() {
+		SearchResult res = searchSinglePoi(loc, SEARCH_RADIUS_DEGREE, new ResultMatcher<>() {
 			@Override
 			public boolean publish(Amenity amenity) {
 				return amenity.getEnName(false).equals(enName);
@@ -521,10 +537,11 @@ public class PoiSearchService {
 			public boolean isCancelled() {
 				return false;
 			}
-		}, null);
+		});
+		return res != null ? searchResultConverter.getPoiFeature(res, null) : null;
 	}
 
-	private Feature searchSinglePoi(LatLon loc, double radiusDegree, ResultMatcher<Amenity> matcher, String timeZone)
+	private SearchResult searchSinglePoi(LatLon loc, double radiusDegree, ResultMatcher<Amenity> matcher)
 			throws IOException {
 		final int mapZoom = 15;
 		LatLon p1 = new LatLon(loc.getLatitude() + radiusDegree, loc.getLongitude() - radiusDegree);
@@ -533,9 +550,8 @@ public class PoiSearchService {
 				MapUtils.get31TileNumberX(p1.getLongitude()), MapUtils.get31TileNumberX(p2.getLongitude()),
 				MapUtils.get31TileNumberY(p1.getLatitude()), MapUtils.get31TileNumberY(p2.getLatitude()), mapZoom,
 				BinaryMapIndexReader.ACCEPT_ALL_POI_TYPE_FILTER, matcher);
-		SearchResult res = searchPoiByReq(req, p1, p2, false);
 
-		return res != null ? searchResultConverter.getPoiFeature(res, timeZone) : null;
+		return searchPoiByReq(req, p1, p2, false);
 	}
 
 	private SearchResult searchPoiByReq(BinaryMapIndexReader.SearchRequest<Amenity> req, LatLon p1, LatLon p2,

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/SearchResultConverter.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/SearchResultConverter.java
@@ -58,7 +58,8 @@ public class SearchResultConverter {
 		// names of all objects matched in a spatial-search result (street, city, ...)
 		MATCHED_OBJECTS("web_matched_objects"), VISIBLE_LEVEL("web_visible_level"),
 		COMPARE_KEY("web_compare_key"), BBOX_LAT_LON("web_bbox_lat_lon"),
-		WIKIDATA_ID("web_wikidata_id"), CITY_TYPE("web_city_type"), ELO("web_poi_elo");
+		WIKIDATA_ID("web_wikidata_id"), CITY_TYPE("web_city_type"), ELO("web_poi_elo"),
+		TRANSPORT_STOP_ID("web_transport_stop_id");
 
 		private final String fieldName;
 

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/SearchController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/SearchController.java
@@ -181,29 +181,39 @@ public class SearchController {
 	@ResponseBody
 	public ResponseEntity<String> visibleTags(@RequestBody Map<String, String> tags,
 	                                          @RequestParam(required = false) String lang) {
-		if (tags != null) {
-			if (tags.size() > MAX_TAG_ENTRIES) {
-				return ResponseEntity.badRequest().body(gson.toJson(Map.of(
-						"error", "Too many tags " + tags.size() + ", maximum is " + MAX_TAG_ENTRIES)));
-			}
-			for (Map.Entry<String, String> entry : tags.entrySet()) {
-				String value = entry.getValue();
-				if (value == null) {
-					continue;
-				}
-				if (value.length() > MAX_TAG_VALUE_LENGTH) {
-					return ResponseEntity.badRequest().body(gson.toJson(Map.of(
-							"error", "Tag '" + entry.getKey() + "' value is too long, maximum is "
-									+ MAX_TAG_VALUE_LENGTH + " characters")));
-				}
-				if (MapObject.isContentZipped(value)) {
-					return ResponseEntity.badRequest().body(gson.toJson(Map.of(
-							"error", "Tag '" + entry.getKey() + "' has an unsupported value encoding")));
-				}
-			}
+		ResponseEntity<String> error = validateTags(tags);
+		if (error != null) {
+			return error;
 		}
 		List<AmenityTagsService.VisibleTag> visibleTags = amenityTagsService.convertToVisibleTags(tags, lang);
 		return ResponseEntity.ok(gson.toJson(visibleTags));
+	}
+
+	// tags sent by a client: null when valid, else the error response
+	private ResponseEntity<String> validateTags(Map<String, String> tags) {
+		if (tags == null) {
+			return null;
+		}
+		if (tags.size() > MAX_TAG_ENTRIES) {
+			return ResponseEntity.badRequest().body(gson.toJson(Map.of(
+					"error", "Too many tags " + tags.size() + ", maximum is " + MAX_TAG_ENTRIES)));
+		}
+		for (Map.Entry<String, String> entry : tags.entrySet()) {
+			String value = entry.getValue();
+			if (value == null) {
+				continue;
+			}
+			if (value.length() > MAX_TAG_VALUE_LENGTH) {
+				return ResponseEntity.badRequest().body(gson.toJson(Map.of(
+						"error", "Tag '" + entry.getKey() + "' value is too long, maximum is "
+								+ MAX_TAG_VALUE_LENGTH + " characters")));
+			}
+			if (MapObject.isContentZipped(value)) {
+				return ResponseEntity.badRequest().body(gson.toJson(Map.of(
+						"error", "Tag '" + entry.getKey() + "' has an unsupported value encoding")));
+			}
+		}
+		return null;
 	}
 
 	@GetMapping(path = {"/get-top-filters"}, produces = "application/json")
@@ -358,6 +368,10 @@ public class SearchController {
 	                                                @RequestParam double lon,
 	                                                @RequestParam long id,
 	                                                @RequestParam(required = false) String timeZone) throws IOException {
+		ResponseEntity<String> error = validateTags(tags);
+		if (error != null) {
+			return error;
+		}
 		Feature poi = poiSearchService.getPoiByMapObject(id, new LatLon(lat, lon), tags, timeZone);
 		return ResponseEntity.ok(gson.toJson(poi));
 	}

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/SearchController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/SearchController.java
@@ -345,20 +345,20 @@ public class SearchController {
 	public ResponseEntity<String> getPoiByOsmId(@RequestParam double lat,
 	                                            @RequestParam double lon,
 	                                            @RequestParam long osmid,
-	                                            @RequestParam(required = false) String type,
+	                                            @RequestParam String type,
 	                                            @RequestParam(required = false) String timeZone) throws IOException {
 		Feature poi = poiSearchService.searchPoiByOsmId(new LatLon(lat, lon), osmid, type, timeZone);
 		return ResponseEntity.ok(gson.toJson(poi));
 	}
 
-	@PostMapping(path = {"/get-poi-by-tags"}, produces = "application/json")
+	@PostMapping(path = {"/get-poi-by-map-object"}, produces = "application/json")
 	@ResponseBody
-	public ResponseEntity<String> getPoiByTags(@RequestBody Map<String, String> tags,
-	                                           @RequestParam double lat,
-	                                           @RequestParam double lon,
-	                                           @RequestParam long id,
-	                                           @RequestParam(required = false) String timeZone) throws IOException {
-		Feature poi = poiSearchService.getPoiByTags(tags, new LatLon(lat, lon), id, timeZone);
+	public ResponseEntity<String> getPoiByMapObject(@RequestBody Map<String, String> tags,
+	                                                @RequestParam double lat,
+	                                                @RequestParam double lon,
+	                                                @RequestParam long id,
+	                                                @RequestParam(required = false) String timeZone) throws IOException {
+		Feature poi = poiSearchService.getPoiByMapObject(id, new LatLon(lat, lon), tags, timeZone);
 		return ResponseEntity.ok(gson.toJson(poi));
 	}
 

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/SearchController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/SearchController.java
@@ -345,7 +345,7 @@ public class SearchController {
 	public ResponseEntity<String> getPoiByOsmId(@RequestParam double lat,
 	                                            @RequestParam double lon,
 	                                            @RequestParam long osmid,
-	                                            @RequestParam String type,
+	                                            @RequestParam(required = false) String type,
 	                                            @RequestParam(required = false) String timeZone) throws IOException {
 		Feature poi = poiSearchService.searchPoiByOsmId(new LatLon(lat, lon), osmid, type, timeZone);
 		return ResponseEntity.ok(gson.toJson(poi));

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/SearchController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/pub/SearchController.java
@@ -351,6 +351,17 @@ public class SearchController {
 		return ResponseEntity.ok(gson.toJson(poi));
 	}
 
+	@PostMapping(path = {"/get-poi-by-tags"}, produces = "application/json")
+	@ResponseBody
+	public ResponseEntity<String> getPoiByTags(@RequestBody Map<String, String> tags,
+	                                           @RequestParam double lat,
+	                                           @RequestParam double lon,
+	                                           @RequestParam long id,
+	                                           @RequestParam(required = false) String timeZone) throws IOException {
+		Feature poi = poiSearchService.getPoiByTags(tags, new LatLon(lat, lon), id, timeZone);
+		return ResponseEntity.ok(gson.toJson(poi));
+	}
+
 	@GetMapping(path = {"/get-poi-by-name"}, produces = "application/json")
 	@ResponseBody
 	public ResponseEntity<String> getPoiByOsmId(@RequestParam double lat,


### PR DESCRIPTION
## AI disclaimer

Written with Claude (Cowork, Claude Fable 5.1), driven by [@alisa911](https://github.com/alisa911). Summary of the requests it worked from, in order:

1. Study osmandapp/OsmAnd-Issues#3263, the web and the server projects and write an implementation plan; the Dev notes are recommendations, the Expected Result (tags of a vector tile object equal to search results and the mobile app) is binding. The plan: the server returns the same POI feature as search does, the web only shows it.
2. Widen the POI search radius for ways. `PoiSearchService.searchPoiByOsmId`: 11 m for a node, 600 m otherwise, because the amenity of a way or relation is stored at its centroid.
3. Remove the hardcoded transport stop tags and osm type calculation from the web, do it on the server as Android does. `TransportStopsService.isPublicTransportStop` and `findBestTransportStopId` (port of Android `TransportStopHelper`: 150/400 m, name, location and exit matching, else the nearest stop), `get-transport-stop` searches within 400 m, the POI feature gets `web_transport_stop_id`. The author asked what exactly changed on the server, why `type` became optional and whether `get-poi-by-osmid` is used only for MVT (it is not, Explore uses it with `type`).
4. A parking clicked on the map has no POI in the index (a `no_indx` type): add `get-poi-by-tags` that builds the amenity from the tile tags without duplicating code. `EntityParser.parseAmenities` and `ObfConstants.getOsmObjectId`/`getOsmEntityType(RenderedObject)` are reused after the author rejected a nested ternary and a new helper written by the agent; two constants the agent had reordered in `searchPoiByOsmId` were restored. Separate commits for the transport part and the rest.
5. Go through the review of the PR and say what is agreed. Fixed on approval: the dead `feature != null` check, the redundant `node.replaceTags`, and `get-poi-by-tags` replaced by `get-poi-by-map-object` that takes the osm id and entity type from the map object id, searches the index and falls back to the tags, so the web makes one request instead of two and `type` in `get-poi-by-osmid` is required again. Not changed with reasons: the first parsed amenity depends on the tag order as in Android `convertRenderedObjectToAmenity`, the `RenderedObject` used to decode the id is the existing API, the radius 180 vs 150 was left for the author's decision.
6. Copilot comments: the tag validation of `visible-tags` is shared with the new endpoint through `SearchController.validateTags`. The null-safety comments were declined: `MapObject.getName`/`getEnName` return an empty string, and the request body is required, so `tags` cannot be null.

The agent made no commits. The Java code was not compiled or run by the agent; the earlier version of the endpoints (`get-poi-by-osmid` without `type` and `get-poi-by-tags`) was checked by the agent against the author's deployment on test.osmand.net with the web client, the final `get-poi-by-map-object` and `validateTags` were not executed by the agent. The selenium test of the web PR was run by the author.