### PR TITLE
Remove obsolete GitHub OAuth support (LLM)

### DIFF
--- a/java-tools/OsmAndServer/build.gradle
+++ b/java-tools/OsmAndServer/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
-    implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
     // implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
     implementation "org.javassist:javassist:3.25.0-GA"
     implementation "javax.xml.bind:jaxb-api:2.3.1"
@@ -86,9 +85,6 @@ dependencies {
     implementation "nl.basjes.parse.httpdlog:httpdlog-parser:5.1"
 
     implementation "org.telegram:telegrambots:5.7.1"
-
-    implementation 'org.springframework.security.oauth:spring-security-oauth2:2.5.2.RELEASE'
-    implementation "org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:2.0.1.RELEASE"
 
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.1019')

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/WebSecurityConfiguration.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/WebSecurityConfiguration.java
@@ -38,7 +38,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
@@ -59,7 +58,6 @@ import net.osmand.server.api.services.UserdataService;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableOAuth2Client
 @EnableMethodSecurity
 public class WebSecurityConfiguration {
 	
@@ -67,11 +65,7 @@ public class WebSecurityConfiguration {
 	public static final String ROLE_PRO_USER = "ROLE_PRO_USER"; // actually it's logged in user not necessarily pro
 	public static final String ROLE_ADMIN = "ROLE_ADMIN";
 	public static final String ROLE_SUPPORT = "ROLE_SUPPORT";
-	public static final String ROLE_USER = "ROLE_USER";
 	private static final int SESSION_TTL_SECONDS = 3600 * 24 * 30;
-    
-    @Value("${admin.api-oauth2-url}")
-    private String adminOauth2Url;
 
 	@Value("${spring.session.redisHost}")
 	private String redisHost;

--- a/java-tools/OsmAndServer/src/main/resources/application.yml
+++ b/java-tools/OsmAndServer/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 
-admin.api-oauth2-url: https://api.github.com/orgs/osmandapp/teams/serveradmins
-
 google.androidPublisher.clientSecret: ${ANDROID_PUBLISHER_CLIENT_SECRET_JSON:}
 
 # local storage to store files in db
@@ -128,15 +126,6 @@ spring:
   thymeleaf:
     prefix: file:${osmand.web.location}/templates/
     cache: false
-  security:
-   oauth2:
-     client:
-       registration:
-         github:
-           clientId: ${GITHUB_CLIENT_ID:42f89eddbf81c54c518a}
-           clientSecret: ${GITHUB_CLIENT_SECRET:180c2863aaabb15c7e779bb192c88f1a726507d5}
-           scope: read:org,user:email
-           # creds for localhost
 
 
 # classpath:/static/


### PR DESCRIPTION
GitHub sign-in was removed in May 2025, but its default credentials, configuration and dependencies remained. Remove the GitHub OAuth registration and admin URL from `application.yml`, the unused `@EnableOAuth2Client`, `adminOauth2Url` and `ROLE_USER`, and three Spring OAuth dependencies.

Validation: YAML parsing and comparison confirmed that only the obsolete settings were removed; searches found no remaining references in server sources or build configuration; `git diff --check` passed. Gradle, compilation and server startup were not run.

## AI disclaimer

Produced with Codex (GPT-6).

Prompts used (summarised):
1. Analyze how `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are used, how to check their validity, and whether they can be removed from YAML.
2. Write a Python credential checker and explain how to revoke the OAuth app.
3. Explain why the server no longer needs the client ID and identify the separate GitHub Projects token and where it is configured.
4. Remove the obsolete GitHub OAuth YAML and unused code, then explain why `ROLE_USER` was removed.
5. Suggest a commit title of at most 50 characters ending with `(LLM)`.
6. After the user committed the change, create a draft PR with the AI disclaimer required by the Android `AGENTS.md`.

Decided by the agent, not requested explicitly: classified the unreferenced `ROLE_USER` constant and three Spring OAuth dependencies as part of the obsolete cleanup. For the separately requested diagnostic script, selected a read-only GitHub `/meta` Basic Auth check with an invalid-secret control and separate YAML/environment input modes; that local script is not included in this PR.
