### PR TITLE
Fix user data search: require all query tokens

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/UserDataSearchService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/search/UserDataSearchService.java
@@ -93,7 +93,7 @@ public class UserDataSearchService {
 		final Map<String, NamesIndex> wptsByTrack = new ConcurrentHashMap<>();
 	}
 
-	private record Match(UserDataItem item, int matchedTokens) {
+	private record Match(UserDataItem item, int exactTokens) {
 	}
 
 	// Called from get-shared-with-me for favorites
@@ -127,7 +127,7 @@ public class UserDataSearchService {
 			indexes.forEach(index -> collectMatches(index, tokens, matches));
 		}
 		return matches.stream()
-				.sorted(Comparator.comparingInt(Match::matchedTokens).reversed()
+				.sorted(Comparator.comparingInt(Match::exactTokens).reversed()
 						.thenComparing(match -> match.item().name()))
 				.limit(RESULTS_LIMIT).map(Match::item).toList();
 	}
@@ -228,17 +228,24 @@ public class UserDataSearchService {
 		return index;
 	}
 
-	// Count query tokens matched by prefix in item name tokens
+	// Item matches when every query token is a prefix of some token of its name; exact word matches rank higher
 	private void collectMatches(NamesIndex index, List<String> tokens, List<Match> matches) {
+		if (tokens.isEmpty()) {
+			return;
+		}
 		int[] matchedTokens = new int[index.items.size()];
+		int[] exactTokens = new int[index.items.size()];
 		for (String token : tokens) {
 			for (int position : new HashSet<>(index.tree.simpleGet(token + CollatorStringMatcher.INCOMPLETE_DOT))) {
 				matchedTokens[position]++;
 			}
+			for (int position : new HashSet<>(index.tree.simpleGet(token))) {
+				exactTokens[position]++;
+			}
 		}
 		for (int position = 0; position < matchedTokens.length; position++) {
-			if (matchedTokens[position] > 0) {
-				matches.add(new Match(index.items.get(position), matchedTokens[position]));
+			if (matchedTokens[position] == tokens.size()) {
+				matches.add(new Match(index.items.get(position), exactTokens[position]));
 			}
 		}
 	}


### PR DESCRIPTION
## AI disclaimer

Written with Claude (Cowork, Claude Fable 5.1), driven by [@alisa911](https://github.com/alisa911). Summary of the requests it worked from, in order:

1. Study the web and server projects and recap how favorites and tracks get into search results. Traced the flow: `SearchLayer.searchByWord` calls `POST /mapapi/search-user-data` with the query and the opened tracks that have waypoints; `UserDataSearchService` keeps a per-user in-memory index (tracks by file name, favorites and shared favorites by file, waypoints of opened tracks) and matches query tokens against a `StringPrefixTree`; the web prepends the returned tracks, favorites and waypoints to the server results.
2. Explain how favorites are matched on the server, class and line. `UserDataSearchService.collectMatches` counted query tokens that prefix-match a word of the item name and accepted any item with `matchedTokens > 0`; `searchIndexes` sorted by that count, then by name, limit 8 per category.
3. Screenshot of the query "laan van de heelende" returning `travel/Puerto de la Cruz.gpx` and `import/phuket-de.gpx`, with a question why it was not done right from the start. Cause: the `> 0` condition is OR over tokens, so the single token "de" matched those tracks. Proposed AND (all tokens must match), a threshold, or ignoring short tokens; the code was not touched until the author chose.
4. Fix it. `collectMatches` now accepts an item only when `matchedTokens == tokens.size()` and returns nothing for an empty query; since the count no longer differed between results, `record Match` was removed and `searchIndexes` sorted by name only.
5. Asked whether sorting was gone, then asked to rank exact word matches above prefix matches. Checked `StringPrefixTree.simpleGet` in OsmAnd-java: without a trailing dot it is an exact word lookup. `collectMatches` now also counts exact matches per item; `Match(item, exactTokens)` is back and `searchIndexes` sorts by `exactTokens` descending, then by name, limit 8.

No commits were made by the agent. There are no unit tests for `UserDataSearchService`; the change was not compiled or run by the agent and is to be verified by the author.