### PR TITLE
Routing: pick maps with a 30 km margin around the start/end bbox

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/api/services/OsmAndMapsService.java
@@ -116,6 +116,8 @@ public class OsmAndMapsService {
 
 	private static final int MEM_LIMIT = RoutingConfiguration.DEFAULT_NATIVE_MEMORY_LIMIT * 8;
 	private static final int MEM_MAX_HITS_PER_RUN = 5;
+	// maps are picked by the start/end bbox, but a route with avoid_* / prefer_* params can detour out of it
+	private static final double ROUTING_MAPS_MARGIN_KM = 30;
 
 	private static final long INTERVAL_TO_MONITOR_ZIP = 5 * 60 * 1000;
 	private static final long INTERVAL_TO_CLEANUP_ROUTING_CACHE = 10 * 60 * 1000;
@@ -1049,7 +1051,8 @@ public class OsmAndMapsService {
 					di.selectedCache, di.waitTime / 1e3, di.routeParametersStr, start, end, di.routingCacheInfo));
 			if (ctx == null) {
 				validateAndInitConfig();
-				List<BinaryMapIndexReaderReference> list = getObfReaders(points, ObfReason.ROUTING.value());
+				List<BinaryMapIndexReaderReference> list = getObfReaders(withMargin(points, ROUTING_MAPS_MARGIN_KM),
+						ObfReason.ROUTING.value());
 				boolean[] incomplete = new boolean[1];
 				usedMapList = getReaders(list, incomplete);
 				if (incomplete[0]) {
@@ -1342,6 +1345,21 @@ public class OsmAndMapsService {
 		if (ctx.calculationProgressFirstPhase != null) {
 			props.put("devbase", ctx.calculationProgressFirstPhase.getInfo(null));
 		}
+	}
+
+	// bbox in 31-tile coordinates (top < bottom) expanded by marginKm on each side
+	private static QuadRect withMargin(QuadRect r, double marginKm) {
+		if (r == null) {
+			return null;
+		}
+		double top = MapUtils.get31LatitudeY((int) r.top);
+		double bottom = MapUtils.get31LatitudeY((int) r.bottom);
+		double dLat = marginKm / 111.0;
+		double dLon = marginKm / (111.0 * Math.cos(Math.toRadians((top + bottom) / 2)));
+		return new QuadRect(MapUtils.get31TileNumberX(MapUtils.get31LongitudeX((int) r.left) - dLon),
+				MapUtils.get31TileNumberY(Math.min(top + dLat, MapUtils.MAX_LATITUDE)),
+				MapUtils.get31TileNumberX(MapUtils.get31LongitudeX((int) r.right) + dLon),
+				MapUtils.get31TileNumberY(Math.max(bottom - dLat, MapUtils.MIN_LATITUDE)));
 	}
 
 	public QuadRect points(List<LatLon> intermediates, LatLon start, LatLon end) {


### PR DESCRIPTION
Routes that are not served by an in-memory context (e.g. `motorcycle,avoid_motorway,prefer_unpaved`) use separate OBFs chosen by the bbox of the route points (`getMaps`). With avoid/prefer params the route can detour out of that bbox. HH then cannot find its points in the detailed maps ("End point is not present in detailed maps"), gives up, and the COMPLEX BRP fallback runs for minutes, so the web keeps spinning.

The bbox is now expanded by 30 km before picking the maps for routing.

Reproduced locally with the server's selection and routing path on the Bavaria maps, route Munich 48.085419,11.348877 → Erlangen 49.639177,11.206055, motorcycle + avoid_motorway + prefer_unpaved:

| | maps | result |
|---|---|---|
| before | 5 (no Lower Bavaria) | HH fails after 6 s, BRP fallback reached 25 of 225 km after 90 s |
| after | 7 | 323.6 km in 3.6 s |

Map count for other routes, margin 0 → 30 km: Berlin–Munich 15 → 17, Paris–Lyon 19 → 20, Munich–Ingolstadt 2 → 5.

Not in this PR: Berlin–Munich and Paris–Lyon with the same params also fail on the planet `route.obf`, where all maps are loaded. That is an HH recalculation issue and is handled separately.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Investigate why a motorcycle route with avoid_motorway and prefer_unpaved does not build on the web; reproduce it locally, never on production.
2. Expand the map selection area, and check Berlin–Munich and Paris–Lyon too.
3. Open a single PR with only the map selection margin.

Decided by the agent, not requested explicitly: a fixed 30 km margin instead of a percentage of the distance, applied only to the routing map selection.
