### PR TITLE
OsmGpx: fix zero speed on tracks sampled faster than 2 Hz

### DIFF
--- a/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/DownloadOsmGPX.java
+++ b/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/DownloadOsmGPX.java
@@ -644,8 +644,12 @@ public class DownloadOsmGPX {
 							movingTimeMs += dtMs;
 							coordMaxMps = Math.max(coordMaxMps, speedMps);
 						}
+						anchor = p;
+					} else if (dtMs < 0) {
+						anchor = p; // clock went back: measure from here
 					}
-					anchor = p;
+					// otherwise keep the anchor: moving it on every point would never reach MIN_SPEED_INTERVAL_MS
+					// on tracks sampled faster than 2 Hz, and their speed stayed 0
 				}
 			}
 		}


### PR DESCRIPTION
`computeSpeedMetrics` moved the anchor on every point, so on tracks sampled faster than 2 Hz no interval ever reached `MIN_SPEED_INTERVAL_MS` and the speed stayed 0. The heatmap puts those tracks under "No label, no speed". The anchor now moves only when an interval is used, or when the clock goes back.

Tested with `update_activity` on a local copy of the tables holding 1,600 tracks from the Europe sample, master against this change:

- `nospeed` with speed 0: 340 → 13, mostly sunnypilot/dragonpilot logs at 5–10 Hz.
- 45 other tracks changed speed by more than 5%. In the ones checked, the new value matches distance ÷ time of the whole track, e.g. 158 → 75 km/h (whole track 77.5) and 0.4 → 36.5 km/h (35.3).
- `activity` changed on 3 tracks (nospeed → driving). `nospeed` depends on the `<speed>` tag, so the rest keep the label; the heat build reads the speed column.

Split out of #1700.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Rework OsmGpx classification so that changing criteria does not need another GPX parse; check how many garbage and error tracks can be recovered; find the activity errors visible on the heatmap.
2. Use one JSON column instead of many; open a draft PR only if the code is small and obvious, otherwise continue step by step.
3. Start with the database schema change.

Decided by the agent, not requested explicitly: moving this fix out of the schema PR into its own PR.
