### PR TITLE
OsmGpx: ActivityClassifier with speed-checked labels

### DIFF
--- a/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/ActivityClassifier.java
+++ b/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/ActivityClassifier.java
@@ -1,0 +1,196 @@
+package net.osmand.server.osmgpx;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Activity of an OSM GPX trace from stored columns and track_stats only, so the same rules run in parse_tracks and
+ * classify_tracks. A label from the file or its text is accepted only when the track's own speed fits that activity;
+ * otherwise the next label is tried and, when none fits, the activity comes from speed alone.
+ */
+public class ActivityClassifier {
+
+	public static final String NOSPEED = "nospeed";
+	public static final String AVIATION = "aviation";
+	public static final String FOOT = "foot";
+	public static final String CYCLING = "cycling";
+	public static final String DRIVING = "driving";
+
+	// what a track has: text and file labels from osm_gpx_data, everything measured from track_stats
+	public record Track(String name, String description, List<String> tags, String fileActivity, JsonNode stats) {
+	}
+
+	// speedMatches: null without usable speed, otherwise whether the activity fits the track's speed
+	public record Result(String activity, String source, Boolean speedMatches) {
+	}
+
+	// p85 speed range and p95 ceiling (km/h) a label must fit
+	private record Envelope(double minP85, double maxP85, double maxP95) {
+		boolean fits(double p85, double p95) {
+			return p85 >= minP85 && p85 <= maxP85 && p95 <= maxP95;
+		}
+	}
+
+	private static final Map<String, Envelope> GROUP_ENVELOPES = Map.of(
+			"foot", new Envelope(0, 12, 20),
+			"cycling", new Envelope(5, 45, 70),
+			"winter_sport", new Envelope(3, 120, 160),
+			"driving", new Envelope(10, 250, 300),
+			"motorcycling", new Envelope(10, 250, 300),
+			"air_sports", new Envelope(15, 1200, 1300),
+			"water_sport", new Envelope(0, 90, 120));
+	private static final Map<String, Envelope> ACTIVITY_ENVELOPES = Map.ofEntries(
+			Map.entry("road_running", new Envelope(5, 20, 26)),
+			Map.entry("trail_running", new Envelope(4, 20, 26)),
+			Map.entry("e_biking", new Envelope(8, 50, 60)),
+			Map.entry("cross_country_skiing", new Envelope(3, 35, 60)),
+			Map.entry("ski_touring", new Envelope(0, 60, 100)),
+			Map.entry("snowshoeing", new Envelope(0, 10, 16)),
+			Map.entry("aviation", new Envelope(100, 1200, 1300)),
+			Map.entry("paragliding", new Envelope(5, 100, 150)),
+			Map.entry("hang_gliding", new Envelope(5, 100, 150)),
+			Map.entry("kayak", new Envelope(0, 15, 25)),
+			Map.entry("canoe", new Envelope(0, 15, 25)),
+			Map.entry("sup", new Envelope(0, 15, 25)),
+			Map.entry("rafting", new Envelope(0, 20, 30)),
+			Map.entry("swimming_outdoor", new Envelope(0, 6, 10)),
+			Map.entry("train_riding", new Envelope(20, 350, 400)),
+			Map.entry("horse_riding", new Envelope(0, 25, 40)));
+
+	// activities.json keywords that name a place, a road or something generic rather than how the track was made
+	private static final Set<String> STOP_KEYWORDS = Set.of("van", "vehicle", "motorway", "terrain",
+			"feldweg", "feldwege", "racing", "course", "langlauf", "winter", "skating", "designated", "water", "river",
+			"lake", "canal", "waterway", "boat", "boating", "riding", "multi", "climbing", "walkway", "cycleway", "etna",
+			"etnanatura", "rungis", "fitotrack");
+
+	private static final String[] CAR_CREATORS = {"sunnypilot", "dragonpilot", "openpilot"};
+
+	private static final int MIN_POINTS = 10;
+	private static final double MIN_DISTANCE_M = 200;
+	private static final double MIN_MOVING_S = 120;
+	private static final double MIN_TIME_FRAC = 0.9;
+	private static final double SYNTHETIC_CV = 0.03; // generated timestamps: almost constant speed
+	private static final double SYNTHETIC_P95_TO_P50 = 1.08;
+	private static final double FLIGHT_MEDIAN_KMH = 200;
+
+	private final Map<String, String> groups; // activity or group id -> group id
+	private final List<Map.Entry<String, String>> keywords; // normalized keyword -> activity id, longest first
+
+	public ActivityClassifier(Map<String, List<String>> activityKeywords, Map<String, String> activityGroups) {
+		groups = new HashMap<>(activityGroups);
+		Map<String, String> byKeyword = new HashMap<>();
+		activityKeywords.forEach((activity, tags) -> {
+			groups.putIfAbsent(activity, activity); // group ids are activities of their own
+			for (String tag : tags) {
+				String keyword = normalize(tag);
+				if (!keyword.isEmpty() && !STOP_KEYWORDS.contains(keyword)) {
+					byKeyword.putIfAbsent(keyword, activity);
+				}
+			}
+		});
+		keywords = new ArrayList<>(byKeyword.entrySet());
+		keywords.sort(Comparator.comparingInt((Map.Entry<String, String> e) -> -e.getKey().length())
+				.thenComparing(Map.Entry::getKey));
+	}
+
+	public Result classify(Track track) {
+		JsonNode stats = track.stats();
+		if (stats.path("clean_points").asInt() < MIN_POINTS) {
+			return new Result(GarbageClassifier.SPARSE, "garbage", null);
+		}
+		if (stats.path("clean_distance_m").asDouble() < MIN_DISTANCE_M) {
+			return new Result(GarbageClassifier.SHORT, "garbage", null);
+		}
+		boolean timed = stats.has("speed_p85") && stats.path("moving_s").asDouble() >= MIN_MOVING_S
+				&& stats.path("time_frac").asDouble() >= MIN_TIME_FRAC;
+		double p50 = stats.path("speed_p50").asDouble();
+		double p85 = stats.path("speed_p85").asDouble();
+		double p95 = stats.path("speed_p95").asDouble();
+		boolean synthetic = timed && (stats.path("speed_cv").asDouble() < SYNTHETIC_CV
+				|| (p50 > 0 && p95 / p50 < SYNTHETIC_P95_TO_P50));
+		boolean checkSpeed = timed && !synthetic;
+
+		// candidates in the order they are trusted; the first one the speed allows wins
+		String[][] candidates = {
+				{track.fileActivity(), "file"},
+				{creatorActivity(stats.path("creator").asText("")), "creator"},
+				{keyword(String.join(" | ", track.tags())), "tag"},
+				{keyword(track.name()), "name"},
+				{keyword(track.description()), "description"}};
+		for (String[] candidate : candidates) {
+			String activity = candidate[0];
+			if (activity == null || !groups.containsKey(activity)) {
+				continue;
+			}
+			if (!checkSpeed) {
+				return new Result(activity, candidate[1], null);
+			}
+			if (fits(activity, p85, p95)) {
+				return new Result(activity, candidate[1], true);
+			}
+		}
+		if (!checkSpeed) {
+			return new Result(NOSPEED, "none", null);
+		}
+		return new Result(bySpeed(p50, p85, p95), "speed", true);
+	}
+
+	private boolean fits(String activity, double p85, double p95) {
+		Envelope envelope = ACTIVITY_ENVELOPES.get(activity);
+		if (envelope == null) {
+			envelope = GROUP_ENVELOPES.get(groups.get(activity));
+		}
+		return envelope == null || envelope.fits(p85, p95); // no envelope: speed says nothing against it
+	}
+
+	private static String bySpeed(double p50, double p85, double p95) {
+		if (p50 > FLIGHT_MEDIAN_KMH) {
+			return AVIATION;
+		}
+		if (p85 <= 8.5 && p95 <= 14) {
+			return FOOT;
+		}
+		if (p85 <= 32 && p95 <= 50) {
+			return CYCLING;
+		}
+		return DRIVING;
+	}
+
+	private static String creatorActivity(String creator) {
+		String lower = creator.toLowerCase(Locale.ROOT);
+		for (String car : CAR_CREATORS) {
+			if (lower.contains(car)) {
+				return "car";
+			}
+		}
+		return null;
+	}
+
+	// first keyword, longest first, found as whole words in the text: with hyphens kept and with hyphens as spaces
+	String keyword(String text) {
+		if (text == null || text.isEmpty()) {
+			return null;
+		}
+		String words = " " + normalize(text) + " ";
+		String split = " " + words.replace('-', ' ').trim() + " ";
+		for (Map.Entry<String, String> e : keywords) {
+			String k = " " + e.getKey() + " ";
+			if (words.contains(k) || split.contains(k)) {
+				return e.getValue();
+			}
+		}
+		return null;
+	}
+
+	// lower case, letters, digits and hyphens only, single spaces: "MTB-Tour_2019 (Alps)" -> "mtb-tour 2019 alps"
+	static String normalize(String text) {
+		return text.toLowerCase(Locale.ROOT).replaceAll("[^\\p{L}\\p{N}-]+", " ").trim();
+	}
+}

--- a/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/DownloadOsmGPX.java
+++ b/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/DownloadOsmGPX.java
@@ -127,11 +127,15 @@ public class DownloadOsmGPX {
 	private static final double MIN_MOVING_SPEED_MPS = 0.1; // below this the interval counts as standing still
 	private static final int SRID_WGS84 = 4326;
 	private static final int TRACK_STATS_VERSION = 1;
+	// tracks parse_tracks still has to parse; also the idx_osm_gpx_parse_v* predicate, the query must use the same text
+	private static final String OUTDATED_STATS_CONDITION =
+			"track_stats IS NULL OR COALESCE((track_stats->>'v')::int, 0) < " + TRACK_STATS_VERSION;
 	private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 	private static final int PARSE_BATCH_LIMIT = 1000;
 	private static final int LARGE_GPX_BYTES = 5 << 20; // compressed; larger files are parsed one at a time
 	private static final int CLASSIFY_BATCH_LIMIT = 10000;
 	private static final long TRACK_TIMEOUT_MS = 120_000;
+	private static final long PROGRESS_LOG_MS = 60_000;
 	// lower edges (km/h) of the speed_hist_time / speed_hist_dist bins in track_stats
 	private static final double[] SPEED_BINS_KMH = {1, 3, 5, 7, 9, 12, 16, 20, 25, 32, 45, 60, 90, 130, 180, 300};
 	private static final long SPEED_WINDOW_MIN_MS = 10_000; // windows of >= 10 s and >= 30 m smooth out GPS jitter
@@ -322,6 +326,11 @@ public class DownloadOsmGPX {
 			statement.executeUpdate("ALTER TABLE " + GPX_METADATA_TABLE_NAME + " ADD COLUMN IF NOT EXISTS activity_source text");
 			// facts from one GPX parse, so classification rules can change without parsing again (see computeTrackStats)
 			statement.executeUpdate("ALTER TABLE " + GPX_METADATA_TABLE_NAME + " ADD COLUMN IF NOT EXISTS track_stats json");
+			// ids of the tracks parse_tracks still has to parse: a restarted run starts at once instead of reading
+			// the parsed rows; built once per TRACK_STATS_VERSION, a parsed track leaves it
+			statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_osm_gpx_parse_v" + TRACK_STATS_VERSION
+					+ " ON " + GPX_METADATA_TABLE_NAME + " (id) WHERE " + OUTDATED_STATS_CONDITION);
+			statement.executeUpdate("DROP INDEX IF EXISTS idx_osm_gpx_parse_v" + (TRACK_STATS_VERSION - 1));
 
 			statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_osm_gpx_speed ON " + GPX_METADATA_TABLE_NAME + " (speed)");
 			statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_osm_gpx_distance ON " + GPX_METADATA_TABLE_NAME + " (distance)");
@@ -467,7 +476,7 @@ public class DownloadOsmGPX {
 		if (selection == TrackSelection.WITHOUT_ACTIVITY) {
 			condition += " AND activity IS NULL";
 		} else if (selection == TrackSelection.OUTDATED_STATS) {
-			condition += " AND (track_stats IS NULL OR COALESCE((track_stats->>'v')::int, 0) < " + TRACK_STATS_VERSION + ")";
+			condition += " AND (" + OUTDATED_STATS_CONDITION + ")";
 		}
 		LOG.info("Parsing tracks: " + selection + condition + ", " + options.threads + " threads...");
 		String selectSql = "SELECT id, name, description, tags FROM " + GPX_METADATA_TABLE_NAME
@@ -483,6 +492,7 @@ public class DownloadOsmGPX {
 		Deque<TrackRow> queued = new ArrayDeque<>();
 		long lastId = -1; // so id=0 is included when present
 		boolean moreRows = true;
+		long lastProgressMs = System.currentTimeMillis();
 		dbConn.setAutoCommit(false);
 		try (PreparedStatement selectRows = dbConn.prepareStatement(selectSql);
 			 PreparedStatement selectData = dbConn.prepareStatement("SELECT data FROM " + GPX_FILES_TABLE_NAME + " WHERE id = ?");
@@ -540,6 +550,11 @@ public class DownloadOsmGPX {
 								+ ", marking as error");
 						batch.writeError(task.getValue(), "timeout");
 					}
+				}
+				if (now - lastProgressMs >= PROGRESS_LOG_MS) { // between commits, e.g. while large files are parsed
+					lastProgressMs = now;
+					LOG.info(String.format("Parsing: %d processed, %d running%s, %d queued, last selected id %d",
+							batch.processed, running.size(), largeRunning ? " (a large file alone)" : "", queued.size(), lastId));
 				}
 			}
 			batch.commit();

--- a/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/DownloadOsmGPX.java
+++ b/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/DownloadOsmGPX.java
@@ -24,7 +24,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
@@ -50,9 +49,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.osmand.obf.ToolsOsmAndContextImpl;
 import net.osmand.shared.data.KQuadRect;
-import net.osmand.shared.gpx.RouteActivityHelper;
 import net.osmand.shared.gpx.primitives.Route;
-import net.osmand.shared.gpx.primitives.RouteActivity;
 import net.osmand.shared.gpx.primitives.Track;
 import net.osmand.shared.gpx.primitives.TrkSegment;
 import net.osmand.shared.gpx.primitives.WptPt;
@@ -124,35 +121,7 @@ public class DownloadOsmGPX {
 	private static final int RETRY_TIMEOUT = 15000;
 
 	private static final String ERROR_ACTIVITY_TYPE = "error";
-	private static final String NOSPEED_ACTIVITY_TYPE = "nospeed";
-	private static final String AVIATION_ACTIVITY_TYPE = "aviation";
-	private static final String FOOT_GROUP = "foot";
-	private static final String CYCLING_GROUP = "cycling";
-	private static final String WINTER_SPORT_GROUP = "winter_sport";
-	private static final String DRIVING_GROUP = "driving";
-	private static final String MOTORCYCLING_GROUP = "motorcycling";
-	private static final String OTHER_GROUP = "other";
-
 	private static final Map<String, String> ACTIVITY_GROUPS = new LinkedHashMap<>();
-	private static final Map<String, Double> GROUP_AVG_LIMIT_KMH = Map.of(
-			FOOT_GROUP, 12d,
-			CYCLING_GROUP, 25d,
-			WINTER_SPORT_GROUP, 45d,
-			DRIVING_GROUP, 130d,
-			MOTORCYCLING_GROUP, 130d,
-			AVIATION_ACTIVITY_TYPE, 1000d);
-	private static final Map<String, Double> GROUP_MAX_LIMIT_KMH = Map.of(
-			FOOT_GROUP, 25d,
-			CYCLING_GROUP, 45d,
-			WINTER_SPORT_GROUP, 130d,
-			DRIVING_GROUP, 250d,
-			MOTORCYCLING_GROUP, 300d,
-			AVIATION_ACTIVITY_TYPE, 1200d);
-	private static final List<String> ACTIVITY_BY_SPEED = List.of(
-			FOOT_GROUP, CYCLING_GROUP, DRIVING_GROUP, AVIATION_ACTIVITY_TYPE);
-
-	// Garmin exports named "COURSE_<id>.gpx" would otherwise match "road_running"
-	private static final Set<String> ACTIVITY_KEYWORD_EXCLUSIONS = Set.of("course");
 
 	private static final long MIN_SPEED_INTERVAL_MS = 500; // min elapsed time to trust a speed sample
 	private static final double MIN_MOVING_SPEED_MPS = 0.1; // below this the interval counts as standing still
@@ -188,7 +157,6 @@ public class DownloadOsmGPX {
 	private static final double CLEAN_MIN_PIECE_M = 200;
 
 	private static final String GPX_FILE_PREIX = "OG";
-	private final RouteActivityHelper routeActivityHelper = RouteActivityHelper.INSTANCE;
 
 	private static float round2(float value) {
 		return Math.round(value * 100) / 100.0f;
@@ -446,7 +414,7 @@ public class DownloadOsmGPX {
 					}
 				});
 			} else if (activitiesMap.containsKey(token) || GarbageClassifier.TYPES.contains(token)
-					|| ERROR_ACTIVITY_TYPE.equals(token) || NOSPEED_ACTIVITY_TYPE.equals(token)) {
+					|| ERROR_ACTIVITY_TYPE.equals(token) || ActivityClassifier.NOSPEED.equals(token)) {
 				result.add(token);
 			} else {
 				LOG.info("Unknown category '" + token + "' ignored.");
@@ -518,7 +486,7 @@ public class DownloadOsmGPX {
 		dbConn.setAutoCommit(false);
 		try (PreparedStatement selectRows = dbConn.prepareStatement(selectSql);
 			 PreparedStatement selectData = dbConn.prepareStatement("SELECT data FROM " + GPX_FILES_TABLE_NAME + " WHERE id = ?");
-			 ParseBatch batch = new ParseBatch(activitiesMap)) {
+			 ParseBatch batch = new ParseBatch(new ActivityClassifier(activitiesMap, ACTIVITY_GROUPS))) {
 			while (moreRows || !queued.isEmpty() || !running.isEmpty()) {
 				if (moreRows && queued.isEmpty()) {
 					selectRows.setLong(1, lastId);
@@ -597,10 +565,10 @@ public class DownloadOsmGPX {
 			return;
 		}
 		LOG.info("Classifying tracks from stored columns" + condition + "...");
+		ActivityClassifier classifier = new ActivityClassifier(activitiesMap, ACTIVITY_GROUPS);
 		String selectSql = "SELECT id, name, description, tags, activity, activity_source, speed_matches_activity, "
-				+ "file_activity, points, distance, max_dist_between_points, speed, max_speed, track_stats FROM "
-				+ GPX_METADATA_TABLE_NAME + " WHERE id > ? AND track_stats IS NOT NULL" + condition
-				+ " ORDER BY id LIMIT " + CLASSIFY_BATCH_LIMIT;
+				+ "file_activity, track_stats FROM " + GPX_METADATA_TABLE_NAME + " WHERE id > ? AND track_stats IS NOT NULL"
+				+ condition + " ORDER BY id LIMIT " + CLASSIFY_BATCH_LIMIT;
 		int read = 0;
 		int changed = 0;
 		int skipped = 0;
@@ -619,12 +587,12 @@ public class DownloadOsmGPX {
 						read++;
 						TrackRow row = new TrackRow(rs);
 						lastId = row.id;
-						TrackFacts facts = storedFacts(row, rs);
-						if (facts == null) {
-							skipped++; // error rows, and stats written before the keys classification needs
+						ActivityClassifier.Track track = storedTrack(row, rs);
+						if (track == null) {
+							skipped++; // error rows have no cleaning or speed stats
 							continue;
 						}
-						Classification c = classify(facts, activitiesMap);
+						ActivityClassifier.Result c = classifier.classify(track);
 						if (!Objects.equals(c.activity(), rs.getString("activity"))
 								|| !Objects.equals(c.source(), rs.getString("activity_source"))
 								|| !Objects.equals(c.speedMatches(), rs.getObject("speed_matches_activity"))) {
@@ -684,69 +652,26 @@ public class DownloadOsmGPX {
 		}
 	}
 
-	// what classification reads, from a fresh parse (parse_tracks) or from stored columns (classify_tracks)
-	private static class TrackFacts {
-		TrackRow row;
-		String fileActivity;
-		int points;
-		double distance;
-		double maxDistBetweenPoints;
-		float avgSpeedKmh;
-		float maxSpeedKmh;
-		boolean hasSpeed;
-		boolean teleport;
+	// the track as the classifier sees it, from stored columns; null for rows without cleaning stats (errors)
+	private static ActivityClassifier.Track storedTrack(TrackRow row, ResultSet rs) throws SQLException {
+		JsonNode stats = readStats(rs.getString("track_stats"));
+		if (stats == null || !stats.has("clean_points")) {
+			return null;
+		}
+		return new ActivityClassifier.Track(row.name, row.description, row.tags, rs.getString("file_activity"), stats);
 	}
 
-	record Classification(String activity, String source, Boolean speedMatches) {
-	}
-
-	private Classification classify(TrackFacts facts, Map<String, List<String>> activitiesMap) {
-		String activity = GarbageClassifier.classify(facts.points, facts.distance, facts.maxDistBetweenPoints, facts.teleport);
-		String source = activity != null ? "garbage" : null;
-		// each step runs only when the previous ones found nothing, so the last source set is the one used
-		if (activity == null) {
-			activity = getActivityByFileActivity(facts.fileActivity, activitiesMap);
-			source = "file";
-		}
-		if (activity == null) {
-			activity = analyzeActivity(facts.row.name, facts.row.description, facts.row.tags, activitiesMap);
-			source = "keyword";
-		}
-		Boolean speedMatches = speedMatchesActivity(activity, facts.avgSpeedKmh, facts.maxSpeedKmh);
-		if (activity == null) {
-			activity = analyzeActivityBySpeed(facts.hasSpeed, facts.avgSpeedKmh, facts.maxSpeedKmh);
-			source = "speed";
-		}
-		return new Classification(activity, source, speedMatches);
-	}
-
-	// facts from stored columns, null when track_stats lacks what classification needs
-	private static TrackFacts storedFacts(TrackRow row, ResultSet rs) throws SQLException {
-		JsonNode stats;
+	private static JsonNode readStats(String json) {
 		try {
-			stats = JSON_MAPPER.readTree(rs.getString("track_stats"));
+			return json == null ? null : JSON_MAPPER.readTree(json);
 		} catch (IOException e) {
 			return null;
 		}
-		if (!stats.has("has_speed")) {
-			return null;
-		}
-		TrackFacts facts = new TrackFacts();
-		facts.row = row;
-		facts.fileActivity = rs.getString("file_activity");
-		facts.points = rs.getInt("points");
-		facts.distance = rs.getDouble("distance");
-		facts.maxDistBetweenPoints = rs.getDouble("max_dist_between_points");
-		facts.avgSpeedKmh = rs.getFloat("speed");
-		facts.maxSpeedKmh = rs.getFloat("max_speed");
-		facts.hasSpeed = stats.get("has_speed").asBoolean();
-		facts.teleport = stats.path("teleport").asBoolean();
-		return facts;
 	}
 
 	// writes results of parse_tracks in batches; used only on the thread that owns dbConn
 	private class ParseBatch implements AutoCloseable {
-		private final Map<String, List<String>> activitiesMap;
+		private final ActivityClassifier classifier;
 		private final PreparedStatement metricsStmt;
 		private final PreparedStatement errorStmt;
 		private final long startMs = System.currentTimeMillis();
@@ -754,8 +679,8 @@ public class DownloadOsmGPX {
 		private int processed;
 		private int identified;
 
-		ParseBatch(Map<String, List<String>> activitiesMap) throws SQLException {
-			this.activitiesMap = activitiesMap;
+		ParseBatch(ActivityClassifier classifier) throws SQLException {
+			this.classifier = classifier;
 			metricsStmt = dbConn.prepareStatement(
 					"UPDATE " + GPX_METADATA_TABLE_NAME + " SET activity = ?, speed = ?, distance = ?, points = ?, " +
 							"max_speed = ?, max_dist_between_points = ?, time_minutes = ?, waypoints = ?, " +
@@ -778,18 +703,14 @@ public class DownloadOsmGPX {
 				writeError(row, d.errorReason);
 				return;
 			}
-			TrackFacts facts = new TrackFacts();
-			facts.row = row;
-			facts.fileActivity = d.fileActivity;
-			facts.points = d.pointsCount;
-			// the rounded values that are stored, so classify_tracks makes the same decision from the columns
-			facts.distance = round2(d.distanceMeters);
-			facts.maxDistBetweenPoints = round2(d.maxDistBetweenPoints);
-			facts.avgSpeedKmh = round2(d.avgSpeedKmh);
-			facts.maxSpeedKmh = round2(d.maxSpeedKmh);
-			facts.hasSpeed = d.hasSpeed;
-			facts.teleport = d.teleport;
-			Classification c = classify(facts, activitiesMap);
+			JsonNode stats = readStats(d.trackStats);
+			if (stats == null) {
+				writeError(row, "track_stats");
+				return;
+			}
+			// classified from track_stats as stored, so classify_tracks makes the same decision later
+			ActivityClassifier.Result c = classifier.classify(
+					new ActivityClassifier.Track(row.name, row.description, row.tags, d.fileActivity, stats));
 			metricsStmt.setString(1, c.activity());
 			metricsStmt.setFloat(2, round2(d.avgSpeedKmh));
 			metricsStmt.setFloat(3, round2(d.distanceMeters));
@@ -884,7 +805,6 @@ public class DownloadOsmGPX {
 		}
 		d.simplifiedGeometry = encodeGeometry(gpxFile, clean);
 
-		d.hasSpeed = analysis.getHasSpeedInTrack();
 		d.teleport = GarbageClassifier.hasTeleportGap(gpxFile);
 		d.fileActivity = gpxFile.getMetadata().getExtensionsToRead().get(GpxUtilities.ACTIVITY_TYPE);
 		d.trackStats = computeTrackStats(gpxFile, analysis, d.teleport, clean);
@@ -1308,69 +1228,7 @@ public class DownloadOsmGPX {
 		String fileActivity;
 		String trackStats;
 		String errorReason;
-		boolean hasSpeed;
 		boolean teleport;
-	}
-
-	private String getActivityByFileActivity(String fileActivity, Map<String, List<String>> activitiesMap) {
-		if (fileActivity == null || activitiesMap.isEmpty()) {
-			return null;
-		}
-		for (RouteActivity routeActivity : routeActivityHelper.getActivities()) {
-			if (routeActivity.getId().equals(fileActivity)) {
-				return activitiesMap.containsKey(fileActivity) ? fileActivity : null;
-			}
-		}
-		return null;
-	}
-
-	private String analyzeActivity(String name, String desc, List<String> tags, Map<String, List<String>> activitiesMap) {
-		if (activitiesMap.isEmpty()) {
-			return null;
-		}
-
-		// check tags first
-		for (String tag : tags) {
-			RouteActivity activity = routeActivityHelper.findActivityByTag(tag);
-			if (activity != null && activitiesMap.containsKey(activity.getId())) {
-				return activity.getId();
-			}
-		}
-
-		// check name/desc
-		Map<String, String> tagMap = new LinkedHashMap<>();
-		activitiesMap.forEach((activityId, tagList) ->
-				tagList.stream()
-						.sorted((tag1, tag2) -> Integer.compare(tag2.length(), tag1.length()))
-						.forEach(tag -> tagMap.put(tag, activityId))
-		);
-
-		for (Map.Entry<String, String> entry : tagMap.entrySet()) {
-			String tag = entry.getKey();
-			String activityId = entry.getValue();
-			if (containsWord(name, tag)) {
-				if (ACTIVITY_KEYWORD_EXCLUSIONS.contains(tag)) {
-					continue;
-				}
-				return activityId;
-			}
-			if (containsWord(desc, tag)) {
-				return activityId;
-			}
-		}
-		return null;
-	}
-
-	private static boolean containsWord(String text, String word) {
-		if (text == null) {
-			return false;
-		}
-		for (String part : text.split("[\\s_]+")) {
-			if (part.equalsIgnoreCase(word)) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	private static Map<String, List<String>> createActivitiesMap(String rootPath) {
@@ -1415,35 +1273,6 @@ public class DownloadOsmGPX {
 		}
 
 		return activitiesMap;
-	}
-
-	private String analyzeActivityBySpeed(boolean hasSpeedInTrack, float avgSpeed, float maxSpeed) {
-		if (!hasSpeedInTrack || avgSpeed <= 0) {
-			return NOSPEED_ACTIVITY_TYPE;
-		}
-		for (String type : ACTIVITY_BY_SPEED) {
-			if (avgSpeed <= GROUP_AVG_LIMIT_KMH.get(type) && maxSpeed <= GROUP_MAX_LIMIT_KMH.get(type)) {
-				return type;
-			}
-		}
-		return OTHER_GROUP;
-	}
-
-	@Nullable
-	private static Boolean speedMatchesActivity(String activity, float avgSpeedKmh, float maxSpeedKmh) {
-		if (activity == null || avgSpeedKmh <= 0) {
-			return null;
-		}
-		String group = ACTIVITY_GROUPS.get(activity);
-		if (group == null) {
-			return null; // unknown/garbage/error activity
-		}
-		Double avgLimitKmh = GROUP_AVG_LIMIT_KMH.get(group);
-		Double maxLimitKmh = GROUP_MAX_LIMIT_KMH.get(group);
-		if (avgLimitKmh == null || maxLimitKmh == null) {
-			return null;
-		}
-		return avgSpeedKmh <= avgLimitKmh && maxSpeedKmh <= maxLimitKmh;
 	}
 
 	protected void queryGPXForBBOX(QueryParams qp) throws SQLException, IOException, FactoryConfigurationError, XMLStreamException, InterruptedException, XmlPullParserException {

--- a/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/GarbageClassifier.java
+++ b/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/GarbageClassifier.java
@@ -17,10 +17,7 @@ public final class GarbageClassifier {
 	// The "garbage" category and all its concrete subtypes.
 	public static final Set<String> TYPES = Set.of(GARBAGE, SHORT, SPARSE, TELEPORT);
 
-	private static final int MIN_POINTS = 10;
-	private static final int MIN_DISTANCE = 200;
-	private static final double GAP_MAX_SPEED_KMH = 1200; // above any airliner: crossing a gap faster = teleport = garbage
-	private static final int TELEPORT_GAP_MIN_DISTANCE = 1000; // skip teleport check unless the largest gap exceeds this (m)
+	private static final double GAP_MAX_SPEED_KMH = 1200; // above any airliner: crossing a gap faster = teleport
 	private static final long MIN_SPEED_INTERVAL_MS = 500; // min elapsed time to trust a speed sample
 
 	private GarbageClassifier() {
@@ -28,20 +25,6 @@ public final class GarbageClassifier {
 
 	public static boolean isGarbage(String activity) {
 		return activity != null && activity.startsWith(GARBAGE);
-	}
-
-	// points of the track, distance and the largest gap between points in meters, teleport: hasTeleportGap(track)
-	static String classify(int points, double distance, double maxDistBetweenPoints, boolean teleport) {
-		if (points < MIN_POINTS) {
-			return SPARSE;
-		}
-		if (distance < MIN_DISTANCE) {
-			return SHORT;
-		}
-		if (maxDistBetweenPoints > TELEPORT_GAP_MIN_DISTANCE && teleport) {
-			return TELEPORT;
-		}
-		return null;
 	}
 
 	static boolean hasTeleportGap(GpxFile gpxFile) {


### PR DESCRIPTION
All activity rules move into one class, `ActivityClassifier`, used by both `parse_tracks` and `classify_tracks`. It reads only stored columns and `track_stats`, so labels can be recomputed with `classify_tracks` (Jenkins `UPDATE`) without parsing GPX.

Rules, in order:

1. Garbage from the cleaned track: `clean_points` < 10 → `garbage_sparse`, `clean_distance_m` < 200 m → `garbage_short`. `garbage_teleport` is no longer produced: cleaning already splits teleports.
2. Label candidates, most trusted first: `file_activity`, `creator` (sunnypilot/dragonpilot/openpilot → `car`), tags, name, description. Keywords come from `activities.json`, matched as whole words or phrases (longest first), minus a stop list of words that name places or generic things (`van`, `racing`, `feldweg`, `course`, `canal`/`river`/`lake`/`water`, …).
3. With real timestamps a candidate is accepted only when the track's `speed_p85`/`speed_p95` fit that activity's range (for example walking p85 ≤ 12 km/h, running 5–20, cycling 5–45, car 10–250); otherwise the next candidate is tried.
4. When no candidate fits, the label comes from speed: median above 200 km/h → `aviation`, p85 ≤ 8.5 and p95 ≤ 14 → `foot`, p85 ≤ 32 and p95 ≤ 50 → `cycling`, otherwise `driving`.
5. Without usable timestamps, or with generated ones (`speed_cv` < 0.03 or p95/p50 < 1.08), the first candidate is taken unchecked; without any candidate the track is `nospeed`.

`activity_source` is now `file`, `creator`, `tag`, `name`, `description`, `speed`, `garbage`, `none` or `error`; `speed_matches_activity` says whether the label fits the speed and is null without usable speed. The average/maximum speed limits, the old keyword matcher, the `<speed>`-tag `nospeed` rule and `GarbageClassifier.classify` are removed.

Tested on a local copy of the tables with the 30,000-track Europe sample: `parse_tracks` on master, then `classify_tracks` of this branch on that database; `parse_tracks` of this branch on a fresh copy gives the same activity, source and `speed_matches_activity` on all 30,000 rows. `classify_tracks` took 3.2 s.

| group | master | this branch |
|---|---|---|
| `nospeed` | 11,534 | 996 |
| driving | 4,250 | 9,454 |
| foot | 3,835 | 6,368 |
| cycling | 3,511 | 7,036 |
| `garbage_short` / `garbage_sparse` / `garbage_teleport` | 3,077 / 916 / 510 | 2,932 / 1,073 / 0 |
| motorcycling | 434 | 343 |
| winter sports / other / air sports / water sports | 178 / 101 / 85 / 70 | 186 / 86 / 19 / 8 |
| `error` | 1,499 | 1,499 |

Sources: speed 12,755, tag 5,481, garbage 4,005, creator 2,201, description 2,181, name 742, file 140, none 996. Median per-track p85 by the new label: walking 5.3, hiking 5.2, road running 10.3, mountain biking 15.5, road cycling 19.5, road motorcycling 58, car 65, train 107 km/h. The 143 tracks moving from `garbage_short` to `garbage_sparse` have no readable point.

Known limits: running and slow cycling overlap in speed (376 foot → cycling moves on the sample); bus trips stay `car`.

### Restarting `parse_tracks`

`idx_osm_gpx_parse_v<TRACK_STATS_VERSION>` is a partial index on `id` holding only the tracks whose `track_stats` is missing or older than the current version, the same condition as the parse query. A restarted run takes the next ids from it instead of reading past every parsed row; production build #1183 printed nothing for 15 minutes after its restart. The index is created at job start (one table scan the first time, nearly empty once everything is parsed), and the index of the previous version is dropped when the version goes up. `parse_tracks` also logs progress once a minute, including while a large file is parsed alone.

Tested on the 30,000-track sample: `parse_tracks` with and without the index writes identical rows (all written columns, geometry and `track_stats`); the index is 672 kB for 30,000 rows when built. With `track_stats` reset on the last 50 tracks, the first select uses the index in 3 ms, against 111 ms through the primary key with 29,950 rows removed by the filter; the restarted run parses exactly those 50, the rows stay identical, and `classify_tracks` afterwards changes 0. The progress line was checked with a 1 s interval on a 5,000-track parse.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Think about how to fix activity labels in code, and whether new activities are needed.
2. Top-level groups should match competitors; the current top level is fine, the subgroups under driving are questionable.
3. Write a new class that contains only our rules.
4. Wait for the running PARSE to finish and then run UPDATE; the parsing itself stays as it is.
5. The restarted PARSE took long to start: no id ranges, the stored version should decide what to parse; add the index to this PR.

Decided by the agent, not requested explicitly: the speed ranges per activity and group, the stop list, the order of label sources, the speed thresholds for foot/cycling/driving, reusing the 200 km/h median as the flight test, garbage from cleaned stats with no `garbage_teleport`, keeping `bus`/`taxi` as car keywords, the partial index on `id` named by version with the previous one dropped, and the per-minute progress log.

