### PR TITLE
OsmGpx: label steady fast tracks and planner speeds

### DIFF
--- a/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/ActivityClassifier.java
+++ b/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/ActivityClassifier.java
@@ -78,6 +78,11 @@ public class ActivityClassifier {
 	private static final double MIN_TIME_FRAC = 0.9;
 	private static final double SYNTHETIC_CV = 0.03; // generated timestamps: almost constant speed
 	private static final double SYNTHETIC_P95_TO_P50 = 1.08;
+	// planners set walking or cycling speeds; motorway, rail and flights keep a steady speed above this
+	private static final double PLANNED_MAX_P50_KMH = 50;
+	// GPSies times its routes at 10 km/h whatever the activity, so that speed says nothing
+	private static final double PLANNER_DEFAULT_MIN_KMH = 9.5;
+	private static final double PLANNER_DEFAULT_MAX_KMH = 10.5;
 	private static final double FLIGHT_MEDIAN_KMH = 200;
 
 	private final Map<String, String> groups; // activity or group id -> group id
@@ -113,8 +118,9 @@ public class ActivityClassifier {
 		double p50 = stats.path("speed_p50").asDouble();
 		double p85 = stats.path("speed_p85").asDouble();
 		double p95 = stats.path("speed_p95").asDouble();
-		boolean synthetic = timed && (stats.path("speed_cv").asDouble() < SYNTHETIC_CV
+		boolean steady = timed && (stats.path("speed_cv").asDouble() < SYNTHETIC_CV
 				|| (p50 > 0 && p95 / p50 < SYNTHETIC_P95_TO_P50));
+		boolean synthetic = steady && p50 < PLANNED_MAX_P50_KMH;
 		boolean checkSpeed = timed && !synthetic;
 
 		// candidates in the order they are trusted; the first one the speed allows wins
@@ -137,6 +143,9 @@ public class ActivityClassifier {
 			}
 		}
 		if (!checkSpeed) {
+			if (synthetic && (p50 < PLANNER_DEFAULT_MIN_KMH || p50 > PLANNER_DEFAULT_MAX_KMH)) {
+				return new Result(bySpeed(p50, p85, p95), "speed", null); // the speed picked in the planner
+			}
 			return new Result(NOSPEED, "none", null);
 		}
 		return new Result(bySpeed(p50, p85, p95), "speed", true);


### PR DESCRIPTION
Two changes to `ActivityClassifier` after reviewing the 996 `nospeed` tracks of the 30,000-track sample:

- **A steady speed above 50 km/h is a real recording.** Time counted as generated (`speed_cv` < 0.03 or p95/p50 < 1.08) is now treated as generated only when the median speed is below 50 km/h. Planners set walking or cycling speeds; motorway drives, trains and flights keep a steady speed above that and ended up `nospeed`, for example a train at 137 km/h with 1 s fixes. These tracks now get the normal speed check.
- **The planner's speed labels generated time without any other label.** The group comes from that speed (`activity_source` `speed`, `speed_matches_activity` null because it is not a measured speed). Speeds of 9.5–10.5 km/h stay `nospeed`: GPSies times every route at 10 km/h.

Generated time with a label from the file, creator, tags, name or description keeps that label unchecked, as before.

Tested on the 30,000-track sample: `parse_tracks` of master, then `classify_tracks` of this branch on that database changed 508 rows. 219 `nospeed` tracks got a group: 94 with a steady speed above 50 km/h (driving 89, aviation 5) and 125 with a planner speed (foot 74, cycling 46, driving 5). The 777 others stay `nospeed`: generated at 10 km/h, untimed, moving under 2 minutes or timed on fewer than 90% of points. The other 289 changed rows keep their label and now have `speed_matches_activity` true (252 are dragonpilot drives). `parse_tracks` of this branch on a fresh copy gives the same activity, source and `speed_matches_activity` on all 30,000 rows, and `classify_tracks` after it changes 0.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Show in an HTML page what is inside `nospeed`, and how to name the heatmap filter so people understand what it hides.
2. Lay the tracks out so the decision is easier.
3. Of the proposed buckets, take A (steady high speed) and C (generated time at a speed other than 10 km/h); the others stay as they are.

Decided by the agent, not requested explicitly: the 50 km/h boundary, the 9.5–10.5 km/h band for the GPSies default, `speed_matches_activity` null for planner speeds, and keeping labelled generated-time tracks unchecked.
