### PR TITLE
OsmGpx: public track reviews from the heatmap

### DIFF
--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/WebSecurityConfiguration.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/WebSecurityConfiguration.java
@@ -314,7 +314,7 @@ public class WebSecurityConfiguration {
 		CorsConfiguration configuration = new CorsConfiguration();
 		configuration.setAllowedOrigins(Arrays.asList("https://maptile.osmand.net",
 				"https://docs.osmand.net", "https://osmand.net", "https://www.osmand.net",
-				"https://test.osmand.net", "https://osmbtc.org", "http://localhost:3000"));
+				"https://test.osmand.net", "https://osmbtc.org", "http://localhost:3000", "https://builder.osmand.net"));
 		configuration.setAllowCredentials(true);
 		configuration.setAllowedMethods(Arrays.asList(CorsConfiguration.ALL));
 		configuration.setAllowedHeaders(Arrays.asList("Content-Type"));

--- a/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/user/OsmGpxReviewController.java
+++ b/java-tools/OsmAndServer/src/main/java/net/osmand/server/controllers/user/OsmGpxReviewController.java
@@ -1,0 +1,192 @@
+package net.osmand.server.controllers.user;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.sql.Array;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import jakarta.servlet.http.HttpServletResponse;
+import net.osmand.server.DatasourceConfiguration;
+
+/**
+ * Manual review of OsmGpx tracks from the heatmap page: one verdict per track in osm_gpx_data.manual_review, and a
+ * csv.gz export of the reviewed tracks with their labels, track_stats and geometry. Admin only (/admin/**).
+ */
+@RestController
+@RequestMapping("/admin/osmgpx")
+public class OsmGpxReviewController {
+
+	private static final Log LOG = LogFactory.getLog(OsmGpxReviewController.class);
+	private static final String TABLE = "osm_gpx_data";
+	private static final Set<String> VERDICTS = Set.of("ok", "wrong_activity", "garbage", "simulated", "bad_line");
+	private static final int MAX_COMMENT = 2000;
+	private static final int MAX_IDS = 1000;
+	private static final int EXPORT_BATCH = 500;
+	private static final String[] EXPORT_COLUMNS = {"id", "user", "date", "name", "description", "tags", "lat", "lon", "activity",
+			"activity_source", "file_activity", "speed_matches_activity", "speed", "max_speed", "distance", "points", "time_minutes",
+			"manual_review", "track_stats", "geometry_b64"};
+
+	@Autowired
+	@Qualifier("osmgpxJdbcTemplate")
+	JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	DatasourceConfiguration config;
+
+	private final Gson gson = new Gson();
+
+	public record ReviewRequest(Long id, String verdict, String activity, String comment) {
+	}
+
+	/** saves the verdict of one track; an empty verdict removes it */
+	@PostMapping(path = "/review", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> review(@RequestBody ReviewRequest req, Authentication auth) {
+		if (!config.osmgpxInitialized()) {
+			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("OsmGpx datasource is not initialized");
+		}
+		if (req.id() == null) {
+			return ResponseEntity.badRequest().body("id is required");
+		}
+		String json = null;
+		if (!isBlank(req.verdict())) {
+			if (!VERDICTS.contains(req.verdict())) {
+				return ResponseEntity.badRequest().body("verdict must be one of " + VERDICTS);
+			}
+			if ("wrong_activity".equals(req.verdict()) && isBlank(req.activity())) {
+				return ResponseEntity.badRequest().body("wrong_activity needs the right activity");
+			}
+			JsonObject review = new JsonObject();
+			review.addProperty("verdict", req.verdict());
+			if (!isBlank(req.activity())) {
+				review.addProperty("activity", req.activity().trim());
+			}
+			if (!isBlank(req.comment())) {
+				String comment = req.comment().trim();
+				review.addProperty("comment", comment.length() > MAX_COMMENT ? comment.substring(0, MAX_COMMENT) : comment);
+			}
+			review.addProperty("author", auth == null ? null : auth.getName());
+			review.addProperty("time", Instant.now().toString());
+			json = gson.toJson(review);
+		}
+		int updated = jdbcTemplate.update("UPDATE " + TABLE + " SET manual_review = ?::json WHERE id = ?", json, req.id());
+		if (updated == 0) {
+			return ResponseEntity.notFound().build();
+		}
+		return ResponseEntity.ok(json == null ? "{}" : json);
+	}
+
+	/** verdicts of the given tracks, by id; tracks without one are left out */
+	@GetMapping(path = "/reviews", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> reviews(@RequestParam List<Long> ids) {
+		if (!config.osmgpxInitialized()) {
+			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("OsmGpx datasource is not initialized");
+		}
+		if (ids.isEmpty() || ids.size() > MAX_IDS) {
+			return ResponseEntity.badRequest().body("1 to " + MAX_IDS + " ids");
+		}
+		Map<Long, Object> res = new LinkedHashMap<>();
+		String in = String.join(",", Collections.nCopies(ids.size(), "?"));
+		jdbcTemplate.query("SELECT id, manual_review::text FROM " + TABLE + " WHERE manual_review IS NOT NULL AND id IN (" + in + ")",
+				(RowCallbackHandler) rs -> res.put(rs.getLong(1), gson.fromJson(rs.getString(2), Object.class)), ids.toArray());
+		return ResponseEntity.ok(gson.toJson(res));
+	}
+
+	/** every reviewed track as one csv row, gzip; gpx=true adds the original GPX file (gzip, base64) */
+	@GetMapping(path = "/reviews.csv.gz")
+	public void export(@RequestParam(defaultValue = "false") boolean gpx, HttpServletResponse response) throws IOException {
+		if (!config.osmgpxInitialized()) {
+			response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value(), "OsmGpx datasource is not initialized");
+			return;
+		}
+		response.setContentType("application/gzip");
+		response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"osmgpx-reviews.csv.gz\"");
+		String select = "SELECT m.id, m.\"user\", m.date, m.name, m.description, m.tags, m.lat, m.lon, m.activity, m.activity_source, "
+				+ "m.file_activity, m.speed_matches_activity, m.speed, m.max_speed, m.distance, m.points, m.time_minutes, "
+				+ "m.manual_review::text AS manual_review, m.track_stats::text AS track_stats, m.simplified_geometry"
+				+ (gpx ? ", f.data AS gpx FROM " + TABLE + " m LEFT JOIN osm_gpx_files f ON f.id = m.id" : " FROM " + TABLE + " m")
+				+ " WHERE m.manual_review IS NOT NULL AND m.id > ? ORDER BY m.id LIMIT " + EXPORT_BATCH;
+		int rows = 0;
+		try (Writer w = new OutputStreamWriter(new GZIPOutputStream(response.getOutputStream(), 1 << 16), StandardCharsets.UTF_8)) {
+			w.write(String.join(",", EXPORT_COLUMNS) + (gpx ? ",gpx_gz_b64" : "") + "\n");
+			long lastId = -1;
+			while (true) {
+				long[] last = {-1};
+				jdbcTemplate.query(select, (RowCallbackHandler) rs -> {
+					try {
+						writeRow(w, rs, gpx);
+					} catch (IOException e) {
+						throw new UncheckedIOException(e);
+					}
+					last[0] = rs.getLong("id");
+				}, lastId);
+				if (last[0] < 0) {
+					break;
+				}
+				lastId = last[0];
+				rows++;
+			}
+		}
+		LOG.info("Exported reviewed OsmGpx tracks in " + rows + " batches");
+	}
+
+	private static void writeRow(Writer w, ResultSet rs, boolean gpx) throws IOException, SQLException {
+		Array tags = rs.getArray("tags");
+		byte[] geometry = rs.getBytes("simplified_geometry");
+		String[] values = {rs.getString("id"), rs.getString("user"), rs.getString("date"), rs.getString("name"),
+				rs.getString("description"), tags == null ? null : String.join("|", (String[]) tags.getArray()), rs.getString("lat"),
+				rs.getString("lon"), rs.getString("activity"), rs.getString("activity_source"), rs.getString("file_activity"),
+				rs.getString("speed_matches_activity"), rs.getString("speed"), rs.getString("max_speed"), rs.getString("distance"),
+				rs.getString("points"), rs.getString("time_minutes"), rs.getString("manual_review"), rs.getString("track_stats"),
+				geometry == null ? null : Base64.getEncoder().encodeToString(geometry)};
+		StringBuilder line = new StringBuilder();
+		for (String v : values) {
+			line.append(line.length() == 0 ? "" : ",").append(csv(v));
+		}
+		if (gpx) {
+			byte[] data = rs.getBytes("gpx");
+			line.append(',').append(data == null ? "" : Base64.getEncoder().encodeToString(data));
+		}
+		w.write(line.append('\n').toString());
+	}
+
+	private static String csv(String v) {
+		return v == null ? "" : "\"" + v.replace("\"", "\"\"") + "\"";
+	}
+
+	private static boolean isBlank(String s) {
+		return s == null || s.isBlank();
+	}
+}

--- a/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/DownloadOsmGPX.java
+++ b/java-tools/OsmAndServerUtilities/src/main/java/net/osmand/server/osmgpx/DownloadOsmGPX.java
@@ -326,6 +326,8 @@ public class DownloadOsmGPX {
 			statement.executeUpdate("ALTER TABLE " + GPX_METADATA_TABLE_NAME + " ADD COLUMN IF NOT EXISTS activity_source text");
 			// facts from one GPX parse, so classification rules can change without parsing again (see computeTrackStats)
 			statement.executeUpdate("ALTER TABLE " + GPX_METADATA_TABLE_NAME + " ADD COLUMN IF NOT EXISTS track_stats json");
+			// verdicts people give tracks on the heatmap (OsmGpxReviewController); parsing and classifying never write it
+			statement.executeUpdate("ALTER TABLE " + GPX_METADATA_TABLE_NAME + " ADD COLUMN IF NOT EXISTS manual_review json");
 			// ids of the tracks parse_tracks still has to parse: a restarted run starts at once instead of reading
 			// the parsed rows; built once per TRACK_STATS_VERSION, a parsed track leaves it
 			statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_osm_gpx_parse_v" + TRACK_STATS_VERSION


### PR DESCRIPTION
Reviews of OsmGpx tracks from the heatmap page, so labelled tracks can be collected a few at a time and used to check the classification rules.

- `PubTracksController` under `/api/pubtracks`:
  - `GET /me` → `{signedIn, admin}`.
  - `POST /review` with `{id, verdict, activity, comment}`, signed-in users and admins only (401 otherwise). Verdicts: `ok`, `wrong_activity` (needs the right activity), `bad_quality`, `bad_line`, `simulated`, `garbage`. An empty verdict removes the caller's review.
  - `GET /reviews?ids=…`, public: reviews of up to 1,000 tracks as `admin`, `users` (a list) and `mine` for the caller.
  - `GET /reviews.csv.gz`, public: every reviewed track with name, description, tags, labels and their source, speed and distance columns, reviews, `track_stats` and `simplified_geometry` (base64). `?gpx=true` adds the original GPX. Rows are read 500 at a time by id.
- `osm_gpx_data.manual_review jsonb` holds `{"admin": review, "users": {"<cloud user id>": review}}`. Admins share one review, stored with the author e-mail; each user has their own. Every write is one jsonb `UPDATE`. Nothing public carries the admin e-mail or user ids.
- `DownloadOsmGPX.ensureActivitySchema` adds the column; parsing and classifying never write it.
- CORS allows `https://builder.osmand.net`, where the heatmap page runs.

The heatmap side is a separate change in web-server-config. From zoom 16 a click lists the tracks under it and a click on a line selects one. The page shows the admin verdict, user verdict counts and comments. Signed-in people get one-press quick actions with a comment, prefilled with their own verdict.

Tested:
- compiled against the OsmAndServer build;
- the jsonb writes (user add, replace and remove; admin add and remove; empty rows) on local Postgres 13;
- the heatmap flow in headless Chrome against a local stand-in for these endpoints, as anonymous, two users and an admin.

Not run on the real server.

Before the first review the column has to exist as `jsonb`: the next `Planet__OSM_GPX_Update_Activities` run adds it, or `ALTER TABLE osm_gpx_data ADD COLUMN IF NOT EXISTS manual_review jsonb`. If it was already added as `json` from the earlier version of this PR, drop it first; `ADD COLUMN IF NOT EXISTS` does not change the type.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. The heatmap lets you filter but not mark a track as an error; build a feedback flow on the heatmap site, plus a switch between the colour and the grey map.
2. Save the marks in the database as a manual review column and export them.
3. The export should be gzip with the geometry and everything else, to pull thousands of labelled tracks; comments are useful.
4. The site uses the same database as the Jenkins jobs.
5. From zoom 16 pick single tracks, show them to everyone, quick action buttons (bad quality, wrong activity, …) and a comment field.
6. Make it public under `/api/pubtracks`: admins and signed-in users can add; admin and per-user reviews are stored separately; the export is public without admin or user ids.

Decided by the agent, not requested explicitly: the verdict set, a jsonb column rather than a table, one shared admin review, dropping ids rather than hashing them, `/me` and `mine`, showing other people's comments on the page, the CORS origin, the export columns and batching.
